### PR TITLE
feat: update apiVersion from extensions/v1beta1 to apps/v1

### DIFF
--- a/docs/guide/gitlab/app.yaml.md
+++ b/docs/guide/gitlab/app.yaml.md
@@ -21,13 +21,16 @@ data:
 type: kubernetes.io/dockerconfigjson
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: APP_NAME
   namespace: PROJECT_NS
 spec:
   replicas: APP_REP
+  selector:
+    matchLabels:
+      run: APP_NAME
   template:
     metadata:
       labels:

--- a/docs/guide/metallb.md
+++ b/docs/guide/metallb.md
@@ -53,7 +53,7 @@ speaker-n79l4               1/1       Running   0          4h
 ``` bash
 # 创建测试应用
 $ cat > test-nginx.yaml << EOF
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx3

--- a/docs/guide/rollingupdateWithZeroDowntime.md
+++ b/docs/guide/rollingupdateWithZeroDowntime.md
@@ -87,7 +87,7 @@ k8s精确地控制着整个发布过程，分批次有序地进行着滚动更�
 如果未指定这两个可选参数，则k8s会使用默认配置：  
 ``` bash
 root@kube-aio:~# kubectl get deploy busy -o yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -99,7 +99,7 @@ metadata:
   name: busy
   namespace: default
   resourceVersion: "199461"
-  selfLink: /apis/extensions/v1beta1/namespaces/default/deployments/busy
+  selfLink: /apis/apps/v1/namespaces/default/deployments/busy
   uid: 93fde307-a359-11e8-a93b-525400c61543
 spec:
   progressDeadlineSeconds: 600

--- a/docs/practice/java_war_app.md
+++ b/docs/practice/java_war_app.md
@@ -89,13 +89,16 @@ RUN sed -i 's/^JAVA_OPTS=.*webresources\"$/JAVA_OPTS=\"$JAVA_OPTS -Djava.protoco
 
 ```
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: TemplateProject
   namespace: PROJECT_NS
 spec:
   replicas: APP_REP
+  selector:
+    matchLabels:
+      run: TemplateProject
   template:
     metadata:
       labels:

--- a/manifests/dashboard/kubernetes-dashboard.yaml
+++ b/manifests/dashboard/kubernetes-dashboard.yaml
@@ -90,7 +90,7 @@ subjects:
 # ------------------- Dashboard Deployment ------------------- #
 
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   labels:
     k8s-app: kubernetes-dashboard

--- a/manifests/efk/es-dynamic-pv/es-statefulset.yaml
+++ b/manifests/efk/es-dynamic-pv/es-statefulset.yaml
@@ -47,7 +47,7 @@ roleRef:
   apiGroup: ""
 ---
 # Elasticsearch deployment itself
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elasticsearch-logging

--- a/manifests/efk/es-static-pv/es-statefulset.yaml
+++ b/manifests/efk/es-static-pv/es-statefulset.yaml
@@ -47,7 +47,7 @@ roleRef:
   apiGroup: ""
 ---
 # Elasticsearch deployment itself
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elasticsearch-logging

--- a/manifests/efk/es-without-pv/es-statefulset.yaml
+++ b/manifests/efk/es-without-pv/es-statefulset.yaml
@@ -47,7 +47,7 @@ roleRef:
   apiGroup: ""
 ---
 # Elasticsearch deployment itself
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elasticsearch-logging

--- a/manifests/efk/fluentd-es-ds.yaml
+++ b/manifests/efk/fluentd-es-ds.yaml
@@ -45,7 +45,7 @@ roleRef:
   name: fluentd-es
   apiGroup: ""
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-es-v2.0.2

--- a/manifests/efk/kibana-deployment.yaml
+++ b/manifests/efk/kibana-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kibana-logging

--- a/manifests/es-cluster/elasticsearch/templates/client-deployment.yaml
+++ b/manifests/es-cluster/elasticsearch/templates/client-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -10,6 +10,10 @@ metadata:
   name: {{ template "elasticsearch.client.fullname" . }}
 spec:
   replicas: {{ .Values.client.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      component: "{{ .Values.client.name }}"
   template:
     metadata:
       labels:

--- a/manifests/es-cluster/elasticsearch/templates/data-statefulset.yaml
+++ b/manifests/es-cluster/elasticsearch/templates/data-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
@@ -11,6 +11,10 @@ metadata:
 spec:
   serviceName: {{ template "elasticsearch.data.fullname" . }}
   replicas: {{ .Values.data.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      component: "{{ .Values.data.name }}"
   template:
     metadata:
       labels:

--- a/manifests/es-cluster/elasticsearch/templates/master-statefulset.yaml
+++ b/manifests/es-cluster/elasticsearch/templates/master-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
@@ -11,6 +11,10 @@ metadata:
 spec:
   serviceName: {{ template "elasticsearch.master.fullname" . }}
   replicas: {{ .Values.master.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      component: "{{ .Values.master.name }}"
   template:
     metadata:
       labels:

--- a/manifests/heapster/grafana.yaml
+++ b/manifests/heapster/grafana.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: monitoring-grafana

--- a/manifests/heapster/heapster-only/heapster.yaml
+++ b/manifests/heapster/heapster-only/heapster.yaml
@@ -20,7 +20,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster

--- a/manifests/heapster/heapster.yaml
+++ b/manifests/heapster/heapster.yaml
@@ -20,7 +20,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster

--- a/manifests/heapster/influxdb-with-pv/influxdb.yaml
+++ b/manifests/heapster/influxdb-with-pv/influxdb.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: monitoring-influxdb

--- a/manifests/heapster/influxdb.yaml
+++ b/manifests/heapster/influxdb.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: monitoring-influxdb

--- a/manifests/ingress/traefik/tls/traefik-controller.yaml
+++ b/manifests/ingress/traefik/tls/traefik-controller.yaml
@@ -25,7 +25,7 @@ data:
             KeyFile = "/ssl/tls.key"
 ---
 kind: Deployment
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: traefik-ingress-controller
   namespace: kube-system
@@ -105,7 +105,7 @@ spec:
       nodePort: 23456
       name: http
     - protocol: TCP
-      # 
+      #
       port: 443
       nodePort: 23457
       name: https

--- a/manifests/ingress/traefik/traefik-ingress.yaml
+++ b/manifests/ingress/traefik/traefik-ingress.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: kube-system
 ---
 kind: Deployment
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: traefik-ingress-controller
   namespace: kube-system

--- a/manifests/jenkins/templates/jenkins-master-deployment.yaml
+++ b/manifests/jenkins/templates/jenkins-master-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "jenkins.fullname" . }}

--- a/manifests/mariadb-cluster/mariadb/templates/master-statefulset.yaml
+++ b/manifests/mariadb-cluster/mariadb/templates/master-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "master.fullname" . }}

--- a/manifests/mariadb-cluster/mariadb/templates/slave-statefulset.yaml
+++ b/manifests/mariadb-cluster/mariadb/templates/slave-statefulset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.replication.enabled }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "slave.fullname" . }}

--- a/manifests/metrics-server/metrics-server-deployment.yaml
+++ b/manifests/metrics-server/metrics-server-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server

--- a/manifests/prometheus/dingtalk-webhook.yaml
+++ b/manifests/prometheus/dingtalk-webhook.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -8,6 +8,9 @@ metadata:
   namespace: monitoring
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      run: dingtalk
   template:
     metadata:
       labels:

--- a/manifests/prometheus/grafana/templates/deployment.yaml
+++ b/manifests/prometheus/grafana/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "grafana.fullname" . }}
@@ -21,7 +21,7 @@ spec:
     type: {{ .Values.deploymentStrategy }}
   {{- if ne .Values.deploymentStrategy "RollingUpdate" }}
     rollingUpdate: null
-  {{- end }}    
+  {{- end }}
   template:
     metadata:
       labels:

--- a/manifests/prometheus/prometheus/templates/alertmanager-deployment.yaml
+++ b/manifests/prometheus/prometheus/templates/alertmanager-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.alertmanager.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -12,6 +12,11 @@ metadata:
 spec:
   replicas: {{ .Values.alertmanager.replicaCount }}
   {{- if .Values.server.strategy }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus.name" . }}
+      component: "{{ .Values.alertmanager.name }}"
+      release: {{ .Release.Name }}
   strategy:
 {{ toYaml .Values.server.strategy | indent 4 }}
   {{- end }}

--- a/manifests/prometheus/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/manifests/prometheus/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kubeStateMetrics.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
 {{- if .Values.kubeStateMetrics.deploymentAnnotations }}
@@ -15,6 +15,11 @@ metadata:
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
 spec:
   replicas: {{ .Values.kubeStateMetrics.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus.name" . }}
+      component: "{{ .Values.kubeStateMetrics.name }}"
+      release: {{ .Release.Name }}
   template:
     metadata:
     {{- if .Values.kubeStateMetrics.podAnnotations }}

--- a/manifests/prometheus/prometheus/templates/node-exporter-daemonset.yaml
+++ b/manifests/prometheus/prometheus/templates/node-exporter-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.nodeExporter.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
 {{- if .Values.nodeExporter.deploymentAnnotations }}
@@ -14,6 +14,11 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "prometheus.nodeExporter.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "prometheus.name" . }}
+      component: "{{ .Values.nodeExporter.name }}"
+      release: {{ .Release.Name }}
   {{- if .Values.nodeExporter.updateStrategy }}
   updateStrategy:
 {{ toYaml .Values.nodeExporter.updateStrategy | indent 4 }}

--- a/manifests/prometheus/prometheus/templates/pushgateway-deployment.yaml
+++ b/manifests/prometheus/prometheus/templates/pushgateway-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pushgateway.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -11,6 +11,11 @@ metadata:
   name: {{ template "prometheus.pushgateway.fullname" . }}
 spec:
   replicas: {{ .Values.pushgateway.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus.name" . }}
+      component: "{{ .Values.pushgateway.name }}"
+      release: {{ .Release.Name }}
   template:
     metadata:
     {{- if .Values.pushgateway.podAnnotations }}

--- a/manifests/prometheus/prometheus/templates/server-deployment.yaml
+++ b/manifests/prometheus/prometheus/templates/server-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
 {{- if .Values.server.deploymentAnnotations }}
@@ -14,6 +14,11 @@ metadata:
   name: {{ template "prometheus.server.fullname" . }}
 spec:
   replicas: {{ .Values.server.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus.name" . }}
+      component: "{{ .Values.server.name }}"
+      release: {{ .Release.Name }}
   {{- if .Values.server.strategy }}
   strategy:
 {{ toYaml .Values.server.strategy | indent 4 }}

--- a/roles/calico/templates/calico-v3.4.yaml.j2
+++ b/roles/calico/templates/calico-v3.4.yaml.j2
@@ -1,4 +1,4 @@
-# Calico Version {{ calico_ver }} 
+# Calico Version {{ calico_ver }}
 # https://docs.projectcalico.org/{{ calico_ver_main }}/releases#{{ calico_ver }}
 # This manifest includes the following component versions:
 #   calico/node:{{ calico_ver }}
@@ -69,7 +69,7 @@ data:
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system
@@ -221,7 +221,7 @@ spec:
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"
-            # Set Felix logging 
+            # Set Felix logging
             - name: FELIX_LOGSEVERITYSCREEN
               value: "{{ FELIX_LOG_LVL }}"
             - name: FELIX_HEALTHENABLED
@@ -307,7 +307,7 @@ metadata:
 
 # This manifest deploys the Calico Kubernetes controllers.
 # See https://github.com/projectcalico/kube-controllers
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-kube-controllers

--- a/roles/cilium/files/star_war_example/http-sw-app.yaml
+++ b/roles/cilium/files/star_war_example/http-sw-app.yaml
@@ -11,7 +11,7 @@ spec:
     org: empire
     class: deathstar
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: deathstar

--- a/roles/cilium/templates/cilium.yaml.j2
+++ b/roles/cilium/templates/cilium.yaml.j2
@@ -159,7 +159,7 @@ data:
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -510,7 +510,7 @@ spec:
       maxUnavailable: 2
     type: RollingUpdate
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -838,7 +838,7 @@ metadata:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/roles/cluster-addon/templates/coredns.yaml.j2
+++ b/roles/cluster-addon/templates/coredns.yaml.j2
@@ -77,7 +77,7 @@ data:
         loadbalance
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coredns

--- a/roles/cluster-addon/templates/metallb/metallb.yaml.j2
+++ b/roles/cluster-addon/templates/metallb/metallb.yaml.j2
@@ -115,7 +115,7 @@ roleRef:
   kind: Role
   name: config-watcher
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   namespace: metallb-system
@@ -166,7 +166,7 @@ spec:
           limits:
             cpu: 100m
             memory: 100Mi
-          
+
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -177,7 +177,7 @@ spec:
             - net_raw
 
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: metallb-system
@@ -219,7 +219,7 @@ spec:
           limits:
             cpu: 100m
             memory: 100Mi
-          
+
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/roles/cluster-storage/files/alicloud-disk.yaml
+++ b/roles/cluster-storage/files/alicloud-disk.yaml
@@ -68,12 +68,15 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: alicloud-disk-controller
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: alicloud-disk-controller
   strategy:
     type: Recreate
   template:

--- a/roles/cluster-storage/templates/alicloud-nas/alicloud-nas.yaml.j2
+++ b/roles/cluster-storage/templates/alicloud-nas/alicloud-nas.yaml.j2
@@ -42,12 +42,15 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Deployment
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ storage.aliyun_nas.controller_name }}
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ storage.aliyun_nas.controller_name }}
   strategy:
     type: Recreate
   template:

--- a/roles/cluster-storage/templates/nfs/nfs-client-provisioner.yaml.j2
+++ b/roles/cluster-storage/templates/nfs/nfs-client-provisioner.yaml.j2
@@ -39,7 +39,7 @@ roleRef:
 
 ---
 kind: Deployment
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ storage.nfs.provisioner_name }}
   namespace: kube-system

--- a/roles/flannel/templates/kube-flannel.yaml.j2
+++ b/roles/flannel/templates/kube-flannel.yaml.j2
@@ -79,7 +79,7 @@ data:
       }
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-flannel-ds-amd64
@@ -88,6 +88,10 @@ metadata:
     tier: node
     app: flannel
 spec:
+  selector:
+    matchLabels:
+      tier: node
+      app: flannel
   template:
     metadata:
       labels:
@@ -103,7 +107,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: {{ flanneld_image }} 
+        image: {{ flanneld_image }}
         command:
         - cp
         args:
@@ -117,7 +121,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: {{ flanneld_image }} 
+        image: {{ flanneld_image }}
         command:
         - /opt/bin/flanneld
         args:

--- a/roles/kube-router/templates/kuberouter-all.yaml.j2
+++ b/roles/kube-router/templates/kuberouter-all.yaml.j2
@@ -38,7 +38,7 @@ data:
     current-context: kube-router-context
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -47,6 +47,10 @@ metadata:
   name: kube-router
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-router
+      tier: node
   template:
     metadata:
       labels:
@@ -58,7 +62,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router:{{ kube_router_ver }} 
+        image: cloudnativelabs/kube-router:{{ kube_router_ver }}
         imagePullPolicy: {{ PullPolicy }}
         args:
         - "--run-router=true"
@@ -102,7 +106,7 @@ spec:
       initContainers:
       - name: install-cni
         image: busybox:{{ busybox_ver }}
-        imagePullPolicy: {{ PullPolicy }} 
+        imagePullPolicy: {{ PullPolicy }}
         command:
         - /bin/sh
         - -c
@@ -123,7 +127,7 @@ spec:
         - mountPath: /etc/kube-router
           name: kube-router-cfg
         - name: kubeconfig
-          mountPath: /var/lib/kube-router          
+          mountPath: /var/lib/kube-router
       hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly

--- a/roles/kube-router/templates/kuberouter.yaml.j2
+++ b/roles/kube-router/templates/kuberouter.yaml.j2
@@ -19,7 +19,7 @@ data:
     }
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -28,6 +28,10 @@ metadata:
   name: kube-router
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-router
+      tier: node
   template:
     metadata:
       labels:
@@ -39,7 +43,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router:{{ kube_router_ver }} 
+        image: cloudnativelabs/kube-router:{{ kube_router_ver }}
         imagePullPolicy: {{ PullPolicy }}
         args:
         - "--run-router=true"
@@ -79,7 +83,7 @@ spec:
       initContainers:
       - name: install-cni
         image: busybox:{{ busybox_ver }}
-        imagePullPolicy: {{ PullPolicy }} 
+        imagePullPolicy: {{ PullPolicy }}
         command:
         - /bin/sh
         - -c
@@ -93,7 +97,7 @@ spec:
         - mountPath: /etc/cni/net.d
           name: cni-conf-dir
         - mountPath: /etc/kube-router
-          name: kube-router-cfg       
+          name: kube-router-cfg
       hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly


### PR DESCRIPTION
requirement: k8s v1.10(+)
add missing spec.selector for some files

新开分支更新配置文件 apiVersion 。 k8s 版本最低要求 v1.10:
```
1.6版本之前 apiVsersion：extensions/v1beta1
1.6版本到1.9版本之间：apps/v1beta1
1.9版本之后:apps/v1
```