### PR TITLE
安装新节点后推送所有离线镜像，防止某些镜像在新节点上不存在

### DIFF
--- a/tools/02.addnode.yml
+++ b/tools/02.addnode.yml
@@ -13,3 +13,14 @@
   - { role: flannel, when: "CLUSTER_NETWORK == 'flannel'" }
   - { role: kube-router, when: "CLUSTER_NETWORK == 'kube-router'" }
   - { role: kube-ovn, when: "CLUSTER_NETWORK == 'kube-ovn'" }
+  post_tasks:
+  - name: 推送所有离线镜像包
+    copy: src={{ base_dir }}/down dest=/tmp/
+  - name: 导入所有离线镜像
+    shell: ls /tmp/down/*.tar |while read n;do {{ bin_dir }}/docker load -i $n ;done
+    ignore_errors: true
+    when: "CONTAINER_RUNTIME == 'docker'"
+  - name: 导入所有离线镜像
+    shell: ls /tmp/down/*.tar |while read n;do {{ bin_dir }}/ctr -n=k8s.io images import $n ;done
+    ignore_errors: true
+    when: "CONTAINER_RUNTIME == 'containerd'"


### PR DESCRIPTION
解决cluster-addon步骤中推送镜像在新安装节点上不存在，导致pod启动可能会失败