### PR TITLE
Docker安装增加信任内部仓库

### DIFF
--- a/example/hosts.allinone
+++ b/example/hosts.allinone
@@ -46,10 +46,10 @@ NODE_PORT_RANGE="20000-40000"
 CLUSTER_DNS_DOMAIN="cluster.local."
 
 # Docker data ROOT
-STORAGE_DIR="/var/lib/docker"
+# STORAGE_DIR="/var/lib/docker"
 
 # Docker insecure registry
-INSECURE_REG='["127.0.0.1/8"]'
+# INSECURE_REG='["127.0.0.1/8"]'
 
 # -------- Additional Variables (don't change the default value right now)---
 # Binaries Directory

--- a/example/hosts.allinone
+++ b/example/hosts.allinone
@@ -45,11 +45,11 @@ NODE_PORT_RANGE="20000-40000"
 # Cluster DNS Domain
 CLUSTER_DNS_DOMAIN="cluster.local."
 
-# Docker data ROOT.Default /var/lib/docker
-STORAGE_DIR="/data/docker"
+# Docker data ROOT
+STORAGE_DIR="/var/lib/docker"
 
 # Docker insecure registry
-ADD_REGISTRY='["127.0.0.1/8"]'
+INSECURE_REG='["127.0.0.1/8"]'
 
 # -------- Additional Variables (don't change the default value right now)---
 # Binaries Directory

--- a/example/hosts.allinone
+++ b/example/hosts.allinone
@@ -45,6 +45,12 @@ NODE_PORT_RANGE="20000-40000"
 # Cluster DNS Domain
 CLUSTER_DNS_DOMAIN="cluster.local."
 
+# Docker data ROOT.Default /var/lib/docker
+STORAGE_DIR="/data/docker"
+
+# Docker insecure registry
+ADD_REGISTRY='["127.0.0.1/8"]'
+
 # -------- Additional Variables (don't change the default value right now)---
 # Binaries Directory
 bin_dir="/opt/kube/bin"

--- a/example/hosts.multi-node
+++ b/example/hosts.multi-node
@@ -49,6 +49,12 @@ NODE_PORT_RANGE="20000-40000"
 # Cluster DNS Domain
 CLUSTER_DNS_DOMAIN="cluster.local."
 
+# Docker data ROOT.Default /var/lib/docker
+STORAGE_DIR="/data/docker"
+
+# Docker insecure registry
+ADD_REGISTRY='["127.0.0.1/8"]'
+
 # -------- Additional Variables (don't change the default value right now) ---
 # Binaries Directory
 bin_dir="/opt/kube/bin"

--- a/example/hosts.multi-node
+++ b/example/hosts.multi-node
@@ -49,11 +49,11 @@ NODE_PORT_RANGE="20000-40000"
 # Cluster DNS Domain
 CLUSTER_DNS_DOMAIN="cluster.local."
 
-# Docker data ROOT.Default /var/lib/docker
-STORAGE_DIR="/data/docker"
+# Docker data ROOT
+STORAGE_DIR="/var/lib/docker"
 
 # Docker insecure registry
-ADD_REGISTRY='["127.0.0.1/8"]'
+INSECURE_REG='["127.0.0.1/8"]'
 
 # -------- Additional Variables (don't change the default value right now) ---
 # Binaries Directory

--- a/example/hosts.multi-node
+++ b/example/hosts.multi-node
@@ -50,10 +50,10 @@ NODE_PORT_RANGE="20000-40000"
 CLUSTER_DNS_DOMAIN="cluster.local."
 
 # Docker data ROOT
-STORAGE_DIR="/var/lib/docker"
+# STORAGE_DIR="/var/lib/docker"
 
 # Docker insecure registry
-INSECURE_REG='["127.0.0.1/8"]'
+# INSECURE_REG='["127.0.0.1/8"]'
 
 # -------- Additional Variables (don't change the default value right now) ---
 # Binaries Directory

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -16,3 +16,6 @@ ENABLE_MIRROR_REGISTRY: true
 
 # 设置 docker 仓库镜像
 REG_MIRRORS: '["https://dockerhub.azk8s.cn", "https://docker.mirrors.ustc.edu.cn"]'
+
+# 信任的HTTP仓库
+INSECURE_REG: '["127.0.0.1/8"]'

--- a/roles/docker/templates/daemon.json.j2
+++ b/roles/docker/templates/daemon.json.j2
@@ -5,7 +5,7 @@
 {% if ENABLE_REMOTE_API %}
   "hosts": ["tcp://0.0.0.0:2376", "unix:///var/run/docker.sock"],
 {% endif %}
-  "insecure-registries": {{ ADD_REGISTRY|default([]) }},
+  "insecure-registries": {{ INSECURE_REG }},
   "max-concurrent-downloads": 10,
   "log-driver": "{{ LOG_DRIVER }}",
   "log-level": "{{ LOG_LEVEL }}",

--- a/roles/docker/templates/daemon.json.j2
+++ b/roles/docker/templates/daemon.json.j2
@@ -5,6 +5,7 @@
 {% if ENABLE_REMOTE_API %}
   "hosts": ["tcp://0.0.0.0:2376", "unix:///var/run/docker.sock"],
 {% endif %}
+  "insecure-registries": {{ ADD_REGISTRY|default([]) }},
   "max-concurrent-downloads": 10,
   "log-driver": "{{ LOG_DRIVER }}",
   "log-level": "{{ LOG_LEVEL }}",


### PR DESCRIPTION
1.STORAGE_DIR在示例文件中展示（原本就支持，只是没有在示例文件中展示出来）
2.增加信任的HTTP仓库INSECURE_REG变量，并在示例文件中显式展示出来