### PR TITLE
role deploy use pip install package netaddr

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -131,3 +131,7 @@
 - name: ansible 控制端创建 kubectl 软链接
   file: src={{ base_dir }}/bin/kubectl dest=/usr/bin/kubectl state=link
   ignore_errors: true
+
+- name: pip install netaddr
+  pip:
+    name: netaddr


### PR DESCRIPTION
FAILED! => {"failed": true, "msg": "The ipaddr filter requires python-netaddr be installed on the ansible controller"}