### PR TITLE
fix: ipvs-connection-timeout-issue IPVS模式下服务间长连接通讯的优化，解决Connection reset by peer问题

### DIFF
--- a/roles/prepare/defaults/main.yml
+++ b/roles/prepare/defaults/main.yml
@@ -1,2 +1,5 @@
 # 离线安装系统软件包 (offline|online)
 INSTALL_SOURCE: "online"
+
+# 默认使用kube-proxy的 'iptables' 模式，可选 'ipvs' 模式(experimental)
+PROXY_MODE: "ipvs"

--- a/roles/prepare/tasks/common.yml
+++ b/roles/prepare/tasks/common.yml
@@ -42,6 +42,7 @@
 
 # 设置系统参数for k8s
 # 消除docker info 警告WARNING: bridge-nf-call-ip[6]tables is disabled
+# https://success.docker.com/article/ipvs-connection-timeout-issue 缩短keepalive_time超时时间为600s
 - name: 设置系统参数
   template: src=95-k8s-sysctl.conf.j2 dest=/etc/sysctl.d/95-k8s-sysctl.conf
 

--- a/roles/prepare/templates/95-k8s-sysctl.conf.j2
+++ b/roles/prepare/templates/95-k8s-sysctl.conf.j2
@@ -10,3 +10,8 @@ net.netfilter.nf_conntrack_max=1000000
 vm.swappiness = 0
 vm.max_map_count=655360
 fs.file-max=6553600
+{% if PROXY_MODE == "ipvs" %}
+net.ipv4.tcp_keepalive_time = 600
+net.ipv4.tcp_keepalive_intvl = 30
+net.ipv4.tcp_keepalive_probes = 10
+{% endif %}


### PR DESCRIPTION
```
ipvsadm -l --timeout
Timeout (tcp tcpfin udp): 900 120 300
```

```
sysctl net.ipv4.tcp_keepalive_time net.ipv4.tcp_keepalive_probes net.ipv4.tcp_keepalive_intvl
net.ipv4.tcp_keepalive_time = 7200
net.ipv4.tcp_keepalive_probes = 9
net.ipv4.tcp_keepalive_intvl = 75
```

Enable keepalive at the TCP or application network layers:

TCP Keepalive. In Linux TCP keepalive parameters can be set when opening the socket. The default TCP keepalive settings (sysctls) are:

net.ipv4.tcp_keepalive_time = **7200**: seconds idle before sending the first probe
net.ipv4.tcp_keepalive_intvl = 75: seconds between probes
net.ipv4.tcp_keepalive_probes = 9: number of probes to fail before considering the session failed
The following are the required socket options:

SO_KEEPALIVE = 1 -- enable keepalive. Keep alive must be enabled by the application upon socket creation. There is no OS-level configuration to globally enable TCP keepalive in Linux.
TCP_KEEPIDLE = 600 -- send first probe after 10 minutes idle. This can be set on the host via sysctl ipv4.tcp_keepalive_time. However, containers on kernel 4.13 and later will not inherit this sysctl from the host, and as of EE Engine 18.09 setting sysctls with swarm mode services is not yet supported.
Application keepalive. Reconfigure or modify the application to send some data periodically (heartbeat) over otherwise quiet TCP sessions.

Reconfigure or modify affected TCP client applications to close idle TCP sessions prior to the 15 minute timeout.
