### PR TITLE
修复calico的BGP RR模式下的bgppeer的nodeSelector错误

### DIFF
--- a/docs/setup/network-plugin/calico-bgp-rr.md
+++ b/docs/setup/network-plugin/calico-bgp-rr.md
@@ -118,7 +118,7 @@ metadata:
   name: peer-to-rrs
 spec:
   # 规则1：普通 bgp node 与 rr 建立连接
-  nodeSelector: !has(i-am-a-route-reflector)
+  nodeSelector: "!has(i-am-a-route-reflector)"
   peerSelector: has(i-am-a-route-reflector)
 
 ---
@@ -198,9 +198,9 @@ Calico process is running.
 
 IPv4 BGP status
 +--------------+-----------+-------+----------+-------------+
-| PEER ADDRESS | PEER TYPE | STATE |  SINCE   |    INFO     |
+| PEER ADDRESS |   PEER TYPE   | STATE |  SINCE   |    INFO     |
 +--------------+-----------+-------+----------+-------------+
-| 192.168.1.1 | global    | up    | 11:02:55 | Established |
+| 192.168.1.1 | node specific | up    | 11:02:55 | Established |
 +--------------+-----------+-------+----------+-------------+
 
 IPv6 BGP status
@@ -213,7 +213,7 @@ IPv4 BGP status
 +--------------+-----------+-------+----------+-------------+
 | PEER ADDRESS | PEER TYPE | STATE |  SINCE   |    INFO     |
 +--------------+-----------+-------+----------+-------------+
-| 192.168.1.1 | global    | up    | 11:02:55 | Established |
+| 192.168.1.1 | node specific | up    | 11:02:55 | Established |
 +--------------+-----------+-------+----------+-------------+
 
 IPv6 BGP status
@@ -241,7 +241,7 @@ IPv4 BGP status
 +--------------+-----------+-------+----------+-------------+
 | PEER ADDRESS | PEER TYPE | STATE |  SINCE   |    INFO     |
 +--------------+-----------+-------+----------+-------------+
-| 192.168.1.1 | global    | up    | 11:02:55 | Established |
+| 192.168.1.1 | node specific | up    | 11:02:55 | Established |
 +--------------+-----------+-------+----------+-------------+
 
 IPv6 BGP status


### PR DESCRIPTION
首先要说明的是，按照原文档的配置，最终是可以形成可用的rr节点和bgp连接的，但是不严谨。
根据我实际的操作情况来看，`nodeSelector: !has(i-am-a-route-reflector)` 这种写法是无效的，并且创建出来的bgppeer是不会包含nodeSelector这一字段的，除非加上双引号“”（calico的官方文档也是含有双引号的）。
而之所以原有的写法可以成功，是因为当bgppeer没有nodeSelector时，会将它设置为global的，global的意思就是说所有的节点都会与RR节点建立连接；但很显然，原有的目的是让所有非RR节点与RR节点建立连接，同时RR节点之间建立连接；并且按照原写法rr-mesh这个bgppeer其实也是不起作用的，因为global已包含RR节点之间的连接。