### PR TITLE
服务端口值需要加引号

### DIFF
--- a/docs/setup/network-plugin/flannel.md
+++ b/docs/setup/network-plugin/flannel.md
@@ -78,9 +78,9 @@ FLANNEL_IPMASQ=true
             fieldRef:
               fieldPath: metadata.namespace
         - name: KUBERNETES_SERVICE_HOST   # 指定apiserver的主机地址
-          value: {{ MASTER_IP }}
+          value: "{{ MASTER_IP }}"
         - name: KUBERNETES_SERVICE_PORT   # 指定apiserver的服务端口
-          value: {{ KUBE_APISERVER.split(':')[2] }}      
+          value: "{{ KUBE_APISERVER.split(':')[2] }}"
        ...
 ```
 ### 安装 flannel网络


### PR DESCRIPTION
否则会报 `cannot convert int64 to string` 错误。