### PR TITLE
Dev

### DIFF
--- a/11.harbor.yml
+++ b/11.harbor.yml
@@ -13,6 +13,7 @@
       src: "{{ ca_dir }}/ca.pem"
       dest: "{{ base_dir }}/down/"
       flat: yes
+    when: hostvars[groups.harbor[0]]['SELF_SIGNED_CERT'] == 'yes'
 
 - hosts: 
   - kube-master
@@ -26,45 +27,47 @@
     when: hostvars[groups.harbor[0]]['HARBOR_DOMAIN'] == ''
   
   - block:  
-      - name: Creating cert dir for the docker daemon
-        file: name=/etc/docker/certs.d/{{ harbor_host }} state=directory
-  
-      - name: Installing the HARBOR SERVER's CA cert for docker
-        copy: src={{ base_dir }}/down/ca.pem dest=/etc/docker/certs.d/{{ harbor_host }}/ca.crt
-    when: CONTAINER_RUNTIME == 'docker'
+      - block:  
+        - name: Creating cert dir for the docker daemon
+          file: name=/etc/docker/certs.d/{{ harbor_host }} state=directory
+    
+        - name: Installing the HARBOR SERVER's CA cert for docker
+          copy: src={{ base_dir }}/down/ca.pem dest=/etc/docker/certs.d/{{ harbor_host }}/ca.crt
+        when: CONTAINER_RUNTIME == 'docker'
 
-  - block:  
-      - name: Installing the HARBOR SERVER's CA cert on k8s nodes
-        copy: src={{ base_dir }}/down/ca.pem dest=/usr/share/ca-certificates/harbor-ca.crt
+      - block:  
+        - name: Installing the HARBOR SERVER's CA cert on k8s nodes
+          copy: src={{ base_dir }}/down/ca.pem dest=/usr/share/ca-certificates/harbor-ca.crt
 
-      - name: Add the HARBOR SERVER's CA cert 
-        lineinfile:
-          dest: /etc/ca-certificates.conf
-          state: present
-          regexp: 'harbor-ca'
-          line: 'harbor-ca.crt'
+        - name: Add the HARBOR SERVER's CA cert 
+          lineinfile:
+            dest: /etc/ca-certificates.conf
+            state: present
+            regexp: 'harbor-ca'
+            line: 'harbor-ca.crt'
 
-      - name: Update the trusted ca-certificates
-        shell: 'update-ca-certificates'
+        - name: Update the trusted ca-certificates
+          shell: 'update-ca-certificates'
 
-      - name: restart containerd
-        service: name=containerd state=restarted
-    when:
-    - 'CONTAINER_RUNTIME == "containerd"'
-    - 'ansible_distribution == "Ubuntu"'
+        - name: restart containerd
+          service: name=containerd state=restarted
+        when:
+        - 'CONTAINER_RUNTIME == "containerd"'
+        - 'ansible_distribution == "Ubuntu"'
 
-  - block:  
-      - name: Installing the HARBOR SERVER's CA cert on k8s nodes
-        copy: src={{ base_dir }}/down/ca.pem dest=/etc/pki/ca-trust/source/anchors/harbor-ca.crt
+      - block:  
+        - name: Installing the HARBOR SERVER's CA cert on k8s nodes
+          copy: src={{ base_dir }}/down/ca.pem dest=/etc/pki/ca-trust/source/anchors/harbor-ca.crt
 
-      - name: Update the trusted ca-certificates
-        shell: 'update-ca-trust'
+        - name: Update the trusted ca-certificates
+          shell: 'update-ca-trust'
 
-      - name: restart containerd
-        service: name=containerd state=restarted
-    when:
-    - 'CONTAINER_RUNTIME == "containerd"'
-    - 'ansible_distribution in ["CentOS","RedHat","Amazon"]'
+        - name: restart containerd
+          service: name=containerd state=restarted
+        when:
+        - 'CONTAINER_RUNTIME == "containerd"'
+        - 'ansible_distribution in ["CentOS","RedHat","Amazon"]'
+    when: hostvars[groups.harbor[0]]['SELF_SIGNED_CERT'] == 'yes'
 
   # [optional] if you have a DNS server, add an 'A record' instead
   - name: Adding an '/etc/hosts' entry for the HARBOR DOMAIN
@@ -74,3 +77,20 @@
       regexp: '{{ harbor_host }}'
       line: "{{ groups['harbor'][0] }} {{ harbor_host }}"
     when: "hostvars[groups.harbor[0]]['HARBOR_DOMAIN'] != ''"
+  
+  # [optional] 使用 cloud-init 初始化的虚拟机，hosts 后会重启时被替换，需修改对应的 hosts 模板文件 
+  - name: Adding cloud-init hosts template (debian) entry for the HARBOR DOMAIN
+    lineinfile:
+      dest: /etc/cloud/templates/hosts.debian.tmpl
+      state: present
+      regexp: '{{ harbor_host }}'
+      line: "{{ groups['harbor'][0] }} {{ harbor_host }}"
+    when: 'ansible_distribution in ["Ubuntu","Debian"]'
+
+  - name: Adding cloud-init hosts template (redhat) entry for the HARBOR DOMAIN
+    lineinfile:
+      dest: /etc/cloud/templates/hosts.redhat.tmpl
+      state: present
+      regexp: '{{ harbor_host }}'
+      line: "{{ groups['harbor'][0] }} {{ harbor_host }}"
+    when: 'ansible_distribution in ["CentOS","RedHat","Amazon"]' 

--- a/docs/guide/harbor.md
+++ b/docs/guide/harbor.md
@@ -20,9 +20,11 @@ Habor是由VMWare中国团队开源的容器镜像仓库。事实上，Habor是�
 ``` bash
 # 参数 NEW_INSTALL=(yes/no)：yes表示新建 harbor，并配置k8s节点的docker可以使用harbor仓库
 # no 表示仅配置k8s节点的docker使用已有的harbor仓库
+# 参数 SELF_SIGNED_CERT=(yes/no): yes表示使用自签名证书，即安装程序帮你做一个自己签名的证书（当然这样的证书是得不到浏览器直接认可的）
+# no 表示使用已有的证书，如 letsencrypt 或者其他证书颁发机构，如使用此参数，需把证书提前放在 down 目录下，文件名称分别为：harbor.pem 和 harbor-key.pem
 # 如果不需要设置域名访问 harbor，可以配置参数 HARBOR_DOMAIN=""
 [harbor]
-192.168.1.8 HARBOR_DOMAIN="harbor.yourdomain.com" NEW_INSTALL=yes
+192.168.1.8 HARBOR_DOMAIN="harbor.yourdomain.com" NEW_INSTALL=yes SELF_SIGNED_CERT=yes
 ```
 
 4. 在ansible控制端执行 `ansible-playbook /etc/ansible/11.harbor.yml`，完成harbor安装和docker 客户端配置
@@ -30,7 +32,7 @@ Habor是由VMWare中国团队开源的容器镜像仓库。事实上，Habor是�
 - 安装验证
 
 1. 在harbor节点使用`docker ps -a` 查看harbor容器组件运行情况
-1. 浏览器访问harbor节点的IP地址 `https://$NodeIP`，使用账号 admin 和 密码 Harbor12345 (harbor.cfg 配置文件中的默认)登录系统
+2. 浏览器访问harbor节点的IP地址 `https://$NodeIP`，管理员账号是 admin ，密码见 harbor.cfg(v1.5-v1.7) 或 harbor.yml(v1.8+) 文件 harbor_admin_password 对应值（默认密码 Harbor12345 已被随机生成的16位随机密码替换，不然存在安全隐患)
 
 ### 安装讲解
 
@@ -65,7 +67,7 @@ $ crictl pull harbor.test.lo/pub/hello:v0.1.4
 FATA[0000] pulling image failed: rpc error: code = Unknown desc = failed to resolve image "harbor.test.lo/pub/hello:v0.1.4": no available registry endpoint: failed to do request: Head https://harbor.test.lo/v2/pub/hello/manifests/v0.1.4: x509: certificate signed by unknown authority
 ```
 
-项目脚本`11.harbor.yml`中已经自动为k8s集群的每个node节点配置 docker/containerd 信任自建 harbor 证书；如果你无法运行此脚本，可以参考下述手工配置
+项目脚本`11.harbor.yml`中已经自动为k8s集群的每个node节点配置 docker/containerd 信任自建 harbor 证书；如果你无法运行此脚本，可以参考下述手工配置（使用受信任的正式证书 SELF_SIGNED_CERT=no 可忽略）
 
 #### docker配置信任harbor证书
 
@@ -208,7 +210,7 @@ docker run -it --rm -e DB_USR=root -e DB_PWD=xxxx -v /data/database:/var/lib/mys
 # 因为新老版本数据库结构不一样，需要数据库migration
 docker run -it --rm -e DB_USR=root -e DB_PWD=xxxx -v /data/database:/var/lib/mysql vmware/harbor-db-migrator:1.2 up head
 
-# 修改新版本 harbor.cfg配置，需要保持与老版本相关配置项保持一致，然后执行安装即可
+# 修改新版本 harbor.cfg(v1.5-v1.7) 或 harbor.yml(v1.8+) 配置，需要保持与老版本相关配置项保持一致，然后执行安装即可
 cd /data/harbor
 vi harbor.cfg
 ./install.sh

--- a/example/hosts.allinone
+++ b/example/hosts.allinone
@@ -13,8 +13,9 @@
 
 # [optional] harbor server, a private docker registry
 # 'NEW_INSTALL': 'yes' to install a harbor server; 'no' to integrate with existed one
+# 'SELF_SIGNED_CERT': 'no' you need put files of certificates named harbor.pem and harbor-key.pem in directory 'down'
 [harbor]
-#192.168.1.8 HARBOR_DOMAIN="harbor.yourdomain.com" NEW_INSTALL=no
+#192.168.1.8 HARBOR_DOMAIN="harbor.yourdomain.com" NEW_INSTALL=no SELF_SIGNED_CERT=yes
 
 # [optional] loadbalance for accessing k8s from outside
 [ex-lb]

--- a/example/hosts.multi-node
+++ b/example/hosts.multi-node
@@ -17,8 +17,9 @@
 
 # [optional] harbor server, a private docker registry
 # 'NEW_INSTALL': 'yes' to install a harbor server; 'no' to integrate with existed one
+# 'SELF_SIGNED_CERT': 'no' you need put files of certificates named harbor.pem and harbor-key.pem in directory 'down'
 [harbor]
-#192.168.1.8 HARBOR_DOMAIN="harbor.yourdomain.com" NEW_INSTALL=no
+#192.168.1.8 HARBOR_DOMAIN="harbor.yourdomain.com" NEW_INSTALL=no SELF_SIGNED_CERT=yes
 
 # [optional] loadbalance for accessing k8s from outside
 [ex-lb]

--- a/roles/harbor/tasks/main.yml
+++ b/roles/harbor/tasks/main.yml
@@ -1,51 +1,74 @@
-- name: 创建data目录
+- name: 生成 harbor 随机密码
+  shell: < /dev/urandom tr -dc 0-9A-Za-z-_ | head -c 16
+  register: harbor_password_gen
+
+- name: 生成 DB 随机密码
+  shell: < /dev/urandom tr -dc 0-9A-Za-z-_ | head -c 16
+  register: db_password_gen
+
+- name: 创建 data 目录
   file:
     path: /data
     state: directory
     mode: 0755
 
-# 注册变量result，如果/data目录下存在registry目录说明已经安装过harbor，则不进行安装
-- name: 注册变量result
+# 注册变量 result，如果 /data 目录下存在 registry 目录说明已经安装过 harbor，则不进行安装
+- name: 注册变量 result
   command: ls /data
   register: result
 
 - block:
-    - name: 下发docker compose二进制文件
-      copy: src={{ base_dir }}/bin/docker-compose dest={{ bin_dir }}/docker-compose mode=0755
+  - name: 下发 docker compose 二进制文件
+    copy: src={{ base_dir }}/bin/docker-compose dest={{ bin_dir }}/docker-compose mode=0755
 
-    - name: 下发harbor离线安装包
-      copy:
-        src: "{{ base_dir }}/down/harbor-offline-installer-{{ HARBOR_VER }}.tgz"
-        dest: "/data/harbor-offline-installer-{{ HARBOR_VER }}.tgz"
+  - name: 下发 harbor 离线安装包
+    copy:
+      src: "{{ base_dir }}/down/harbor-offline-installer-{{ HARBOR_VER }}.tgz"
+      dest: "/data/harbor-offline-installer-{{ HARBOR_VER }}.tgz"
 
-    - name: 解压harbor离线安装包
-      shell: "cd /data && tar zxf harbor-offline-installer-{{ HARBOR_VER }}.tgz"
+  - name: 解压 harbor 离线安装包
+    shell: "cd /data && tar zxf harbor-offline-installer-{{ HARBOR_VER }}.tgz"
 
-    - name: 导入harbor所需 docker images
-      shell: "{{ bin_dir }}/docker load -i /data/harbor/harbor.{{ HARBOR_VER }}.tar.gz"
-    
-    - name: 分发证书相关
+  - name: 导入 harbor 所需 docker images
+    shell: "{{ bin_dir }}/docker load -i /data/harbor/harbor.{{ HARBOR_VER }}.tar.gz"
+  
+  - block:
+    - name: 生成自签名证书相关
       copy: src={{ base_dir }}/.cluster/ssl/{{ item }} dest={{ ca_dir }}/{{ item }}
       with_items:
       - ca.pem
       - ca-key.pem
       - ca-config.json
     
-    - name: 创建harbor证书请求
+    - name: 创建 harbor 证书请求
       template: src=harbor-csr.json.j2 dest={{ ca_dir }}/harbor-csr.json
     
-    - name: 创建harbor证书和私钥
+    - name: 创建 harbor 证书和私钥
       shell: "cd {{ ca_dir }} && {{ bin_dir }}/cfssl gencert \
             -ca={{ ca_dir }}/ca.pem \
             -ca-key={{ ca_dir }}/ca-key.pem \
             -config={{ ca_dir }}/ca-config.json \
             -profile=kubernetes harbor-csr.json | {{ bin_dir }}/cfssljson -bare harbor"
-    
-    - name: 配置 harbor.cfg 文件
-      template: src=harbor-{{ HARBOR_VER_MAIN }}.cfg.j2 dest=/data/harbor/harbor.cfg
-    
-    - name: 安装 harbor
-      shell: "cd /data/harbor && \
-    	export PATH={{ bin_dir }}:$PATH && \
-    	 ./install.sh  --with-clair"
+    when: SELF_SIGNED_CERT == 'yes'
+
+  - name: 复制 down 目录下 harbor 证书
+    copy: src={{ base_dir }}/down/{{ item }} dest={{ ca_dir }}/{{ item }}
+    with_items: 
+    - harbor.pem
+    - harbor-key.pem  
+    when: SELF_SIGNED_CERT == 'no'
+  
+  - name: 配置 harbor.cfg 文件
+    template: src=harbor-{{ HARBOR_VER_MAIN }}.cfg.j2 dest=/data/harbor/harbor.cfg
+    when: HARBOR_VER_MAIN in ["v1.5", "v1.6", "v1.7"]
+
+  - name: 配置 harbor.yml 文件
+    template: src=harbor-{{ HARBOR_VER_MAIN }}.yml.j2 dest=/data/harbor/harbor.yml
+    when: HARBOR_VER_MAIN in ["v1.8", "v1.9", "v1.10"]
+  
+  
+  - name: 安装 harbor --with-clair
+    shell: "cd /data/harbor && \
+    export PATH={{ bin_dir }}:$PATH && \
+      ./install.sh  --with-clair"
   when: '"registry" not in result.stdout'

--- a/roles/harbor/templates/harbor-v1.10.yml.j2
+++ b/roles/harbor/templates/harbor-v1.10.yml.j2
@@ -1,0 +1,165 @@
+# Configuration file of Harbor
+
+# The IP address or hostname to access admin UI and registry service.
+# DO NOT use localhost or 127.0.0.1, because Harbor needs to be accessed by external clients.
+hostname: {{ inventory_hostname }}
+
+# http related config
+http:
+  # port for http, default is 80. If https enabled, this port will redirect to https port
+  port: 80
+
+# https related config
+https:
+  # https port for harbor, default is 443
+  port: 443
+  # The path of cert and key files for nginx
+  certificate: {{ ca_dir }}/harbor.pem 
+  private_key: {{ ca_dir }}/harbor-key.pem
+
+# Uncomment external_url if you want to enable external proxy
+# And when it enabled the hostname will no longer used
+# external_url: https://reg.mydomain.com:8433
+
+# The initial password of Harbor admin
+# It only works in first time to install harbor
+# Remember Change the admin password from UI after launching Harbor.
+harbor_admin_password: {{ harbor_password_gen.stdout }}
+
+# Harbor DB configuration
+database:
+  # The password for the root user of Harbor DB. Change this before any production use.
+  password: {{ db_password_gen.stdout }}
+  # The maximum number of connections in the idle connection pool. If it <=0, no idle connections are retained.
+  max_idle_conns: 50
+  # The maximum number of open connections to the database. If it <= 0, then there is no limit on the number of open connections.
+  # Note: the default number of connections is 100 for postgres.
+  max_open_conns: 100
+
+# The default data volume
+data_volume: /data
+
+# Harbor Storage settings by default is using /data dir on local filesystem
+# Uncomment storage_service setting If you want to using external storage
+# storage_service:
+#   # ca_bundle is the path to the custom root ca certificate, which will be injected into the truststore
+#   # of registry's and chart repository's containers.  This is usually needed when the user hosts a internal storage with self signed certificate.
+#   ca_bundle:
+
+#   # storage backend, default is filesystem, options include filesystem, azure, gcs, s3, swift and oss
+#   # for more info about this configuration please refer https://docs.docker.com/registry/configuration/
+#   filesystem:
+#     maxthreads: 100
+#   # set disable to true when you want to disable registry redirect
+#   redirect:
+#     disabled: false
+
+# Clair configuration
+clair:
+  # The interval of clair updaters, the unit is hour, set to 0 to disable the updaters.
+  updaters_interval: 12
+
+jobservice:
+  # Maximum number of job workers in job service
+  max_job_workers: 10
+
+notification:
+  # Maximum retry count for webhook job
+  webhook_job_max_retry: 10
+
+chart:
+  # Change the value of absolute_url to enabled can enable absolute url in chart
+  absolute_url: disabled
+
+# Log configurations
+log:
+  # options are debug, info, warning, error, fatal
+  level: info
+  # configs for logs in local storage
+  local:
+    # Log files are rotated log_rotate_count times before being removed. If count is 0, old versions are removed rather than rotated.
+    rotate_count: 50
+    # Log files are rotated only if they grow bigger than log_rotate_size bytes. If size is followed by k, the size is assumed to be in kilobytes.
+    # If the M is used, the size is in megabytes, and if G is used, the size is in gigabytes. So size 100, size 100k, size 100M and size 100G
+    # are all valid.
+    rotate_size: 200M
+    # The directory on your host that store log
+    location: /var/log/harbor
+
+  # Uncomment following lines to enable external syslog endpoint.
+  # external_endpoint:
+  #   # protocol used to transmit log to external endpoint, options is tcp or udp
+  #   protocol: tcp
+  #   # The host of external endpoint
+  #   host: localhost
+  #   # Port of external endpoint
+  #   port: 5140
+
+#This attribute is for migrator to detect the version of the .cfg file, DO NOT MODIFY!
+_version: 1.10.0
+
+# Uncomment external_database if using external database.
+# external_database:
+#   harbor:
+#     host: harbor_db_host
+#     port: harbor_db_port
+#     db_name: harbor_db_name
+#     username: harbor_db_username
+#     password: harbor_db_password
+#     ssl_mode: disable
+#     max_idle_conns: 2
+#     max_open_conns: 0
+#   clair:
+#     host: clair_db_host
+#     port: clair_db_port
+#     db_name: clair_db_name
+#     username: clair_db_username
+#     password: clair_db_password
+#     ssl_mode: disable
+#   notary_signer:
+#     host: notary_signer_db_host
+#     port: notary_signer_db_port
+#     db_name: notary_signer_db_name
+#     username: notary_signer_db_username
+#     password: notary_signer_db_password
+#     ssl_mode: disable
+#   notary_server:
+#     host: notary_server_db_host
+#     port: notary_server_db_port
+#     db_name: notary_server_db_name
+#     username: notary_server_db_username
+#     password: notary_server_db_password
+#     ssl_mode: disable
+
+# Uncomment external_redis if using external Redis server
+# external_redis:
+#   host: redis
+#   port: 6379
+#   password:
+#   # db_index 0 is for core, it's unchangeable
+#   registry_db_index: 1
+#   jobservice_db_index: 2
+#   chartmuseum_db_index: 3
+#   clair_db_index: 4
+
+# Uncomment uaa for trusting the certificate of uaa instance that is hosted via self-signed cert.
+# uaa:
+#   ca_file: /path/to/ca
+
+# Global proxy
+# Config http proxy for components, e.g. http://my.proxy.com:3128
+# Components doesn't need to connect to each others via http proxy.
+# Remove component from `components` array if want disable proxy
+# for it. If you want use proxy for replication, MUST enable proxy
+# for core and jobservice, and set `http_proxy` and `https_proxy`.
+# Add domain to the `no_proxy` field, when you want disable proxy
+# for some special registry.
+proxy:
+  http_proxy:
+  https_proxy:
+  # no_proxy endpoints will appended to 127.0.0.1,localhost,.local,.internal,log,db,redis,nginx,core,portal,postgresql,jobservice,registry,registryctl,clair,chartmuseum,notary-server
+  no_proxy:
+  components:
+    - core
+    - jobservice
+    - clair

--- a/roles/harbor/templates/harbor-v1.5.cfg.j2
+++ b/roles/harbor/templates/harbor-v1.5.cfg.j2
@@ -65,7 +65,7 @@ email_insecure = false
 ##The initial password of Harbor admin, only works for the first time when Harbor starts. 
 #It has no effect after the first launch of Harbor.
 #Change the admin password from UI after launching Harbor.
-harbor_admin_password = Harbor12345
+harbor_admin_password = {{ harbor_password_gen.stdout }}
 
 ##By default the auth mode is db_auth, i.e. the credentials are stored in a local database.
 #Set it to ldap_auth if you want to verify a user's credentials against an LDAP server.
@@ -130,7 +130,7 @@ project_creation_restriction = everyone
 db_host = mysql
 
 #The password for the root user of Harbor DB. Change this before any production use.
-db_password = root123
+db_password = {{ db_password_gen.stdout }}
 
 #The port of Harbor database host
 db_port = 3306

--- a/roles/harbor/templates/harbor-v1.6.cfg.j2
+++ b/roles/harbor/templates/harbor-v1.6.cfg.j2
@@ -65,7 +65,7 @@ email_insecure = false
 ##The initial password of Harbor admin, only works for the first time when Harbor starts. 
 #It has no effect after the first launch of Harbor.
 #Change the admin password from UI after launching Harbor.
-harbor_admin_password = Harbor12345
+harbor_admin_password = {{ harbor_password_gen.stdout }}
 
 ##By default the auth mode is db_auth, i.e. the credentials are stored in a local database.
 #Set it to ldap_auth if you want to verify a user's credentials against an LDAP server.
@@ -130,7 +130,7 @@ project_creation_restriction = adminonly
 db_host = postgresql
 
 #The password for the root user of Harbor DB. Change this before any production use.
-db_password = root123
+db_password = {{ db_password_gen.stdout }}
 
 #The port of Harbor database host
 db_port = 5432

--- a/roles/harbor/templates/harbor-v1.7.cfg.j2
+++ b/roles/harbor/templates/harbor-v1.7.cfg.j2
@@ -66,7 +66,7 @@ email_insecure = false
 ##The initial password of Harbor admin, only works for the first time when Harbor starts. 
 #It has no effect after the first launch of Harbor.
 #Change the admin password from UI after launching Harbor.
-harbor_admin_password = Harbor12345
+harbor_admin_password = {{ harbor_password_gen.stdout }}
 
 ##By default the auth mode is db_auth, i.e. the credentials are stored in a local database.
 #Set it to ldap_auth if you want to verify a user's credentials against an LDAP server.
@@ -131,7 +131,7 @@ project_creation_restriction = everyone
 db_host = postgresql
 
 #The password for the root user of Harbor DB. Change this before any production use.
-db_password = root123
+db_password = {{ db_password_gen.stdout }}
 
 #The port of Harbor database host
 db_port = 5432

--- a/roles/harbor/templates/harbor-v1.8.yml.j2
+++ b/roles/harbor/templates/harbor-v1.8.yml.j2
@@ -1,0 +1,130 @@
+# Configuration file of Harbor
+
+# The IP address or hostname to access admin UI and registry service.
+# DO NOT use localhost or 127.0.0.1, because Harbor needs to be accessed by external clients.
+hostname: {{ inventory_hostname }}
+
+# http related config
+http:
+  # port for http, default is 80. If https enabled, this port will redirect to https port
+  port: 80
+
+# https related config
+https:
+#   # https port for harbor, default is 443
+  port: 443
+#   # The path of cert and key files for nginx
+  certificate: {{ ca_dir }}/harbor.pem 
+  private_key: {{ ca_dir }}/harbor-key.pem
+
+# Uncomment external_url if you want to enable external proxy
+# And when it enabled the hostname will no longer used
+# external_url: https://reg.mydomain.com:8433
+
+# The initial password of Harbor admin
+# It only works in first time to install harbor
+# Remember Change the admin password from UI after launching Harbor.
+harbor_admin_password: {{ harbor_password_gen.stdout }}
+
+# Harbor DB configuration
+database:
+  # The password for the root user of Harbor DB. Change this before any production use.
+  password: {{ db_password_gen.stdout }}
+
+# The default data volume
+data_volume: /data
+
+# Harbor Storage settings by default is using /data dir on local filesystem
+# Uncomment storage_service setting If you want to using external storage
+# storage_service:
+#   # ca_bundle is the path to the custom root ca certificate, which will be injected into the truststore
+#   # of registry's and chart repository's containers.  This is usually needed when the user hosts a internal storage with self signed certificate.
+#   ca_bundle:
+
+#   # storage backend, default is filesystem, options include filesystem, azure, gcs, s3, swift and oss
+#   # for more info about this configuration please refer https://docs.docker.com/registry/configuration/
+#   filesystem:
+#     maxthreads: 100
+#   # set disable to true when you want to disable registry redirect
+#   redirect:
+#     disabled: false
+
+# Clair configuration
+clair: 
+  # The interval of clair updaters, the unit is hour, set to 0 to disable the updaters.
+  updaters_interval: 12
+
+  # Config http proxy for Clair, e.g. http://my.proxy.com:3128
+  # Clair doesn't need to connect to harbor internal components via http proxy.
+  http_proxy:
+  https_proxy:
+  no_proxy: 127.0.0.1,localhost,core,registry
+
+jobservice:
+  # Maximum number of job workers in job service  
+  max_job_workers: 10
+
+chart:
+  # Change the value of absolute_url to enabled can enable absolute url in chart
+  absolute_url: disabled
+
+# Log configurations
+log:
+  # options are debug, info, warning, error, fatal
+  level: info
+  # Log files are rotated log_rotate_count times before being removed. If count is 0, old versions are removed rather than rotated.
+  rotate_count: 50
+  # Log files are rotated only if they grow bigger than log_rotate_size bytes. If size is followed by k, the size is assumed to be in kilobytes. 
+  # If the M is used, the size is in megabytes, and if G is used, the size is in gigabytes. So size 100, size 100k, size 100M and size 100G 
+  # are all valid.
+  rotate_size: 200M
+  # The directory on your host that store log
+  location: /var/log/harbor
+
+#This attribute is for migrator to detect the version of the .cfg file, DO NOT MODIFY!
+_version: 1.8.0
+
+# Uncomment external_database if using external database.
+# external_database:
+#   harbor:
+#     host: harbor_db_host
+#     port: harbor_db_port
+#     db_name: harbor_db_name
+#     username: harbor_db_username
+#     password: harbor_db_password
+#     ssl_mode: disable
+#   clair:
+#     host: clair_db_host
+#     port: clair_db_port
+#     db_name: clair_db_name
+#     username: clair_db_username
+#     password: clair_db_password
+#     ssl_mode: disable
+#   notary_signer:
+#     host: notary_signer_db_host
+#     port: notary_signer_db_port
+#     db_name: notary_signer_db_name
+#     username: notary_signer_db_username
+#     password: notary_signer_db_password
+#     ssl_mode: disable
+#   notary_server:
+#     host: notary_server_db_host
+#     port: notary_server_db_port
+#     db_name: notary_server_db_name
+#     username: notary_server_db_username
+#     password: notary_server_db_password
+#     ssl_mode: disable
+
+# Uncomment external_redis if using external Redis server
+# external_redis:
+#   host: redis
+#   port: 6379
+#   password:
+#   # db_index 0 is for core, it's unchangeable
+#   registry_db_index: 1
+#   jobservice_db_index: 2
+#   chartmuseum_db_index: 3
+
+# Uncomment uaa for trusting the certificate of uaa instance that is hosted via self-signed cert.
+# uaa:
+#   ca_file: /path/to/ca

--- a/roles/harbor/templates/harbor-v1.9.yml.j2
+++ b/roles/harbor/templates/harbor-v1.9.yml.j2
@@ -1,0 +1,163 @@
+# Configuration file of Harbor
+
+# The IP address or hostname to access admin UI and registry service.
+# DO NOT use localhost or 127.0.0.1, because Harbor needs to be accessed by external clients.
+hostname: {{ inventory_hostname }} 
+
+# http related config
+http:
+  # port for http, default is 80. If https enabled, this port will redirect to https port
+#  port: 80
+
+# https related config
+https:
+#   # https port for harbor, default is 443
+  port: 443
+#   # The path of cert and key files for nginx
+  certificate: {{ ca_dir }}/harbor.pem 
+  private_key: {{ ca_dir }}/harbor-key.pem
+
+# Uncomment external_url if you want to enable external proxy
+# And when it enabled the hostname will no longer used
+# external_url: https://reg.mydomain.com:8433
+
+# The initial password of Harbor admin
+# It only works in first time to install harbor
+# Remember Change the admin password from UI after launching Harbor.
+harbor_admin_password: {{ harbor_password_gen.stdout }}
+
+# Harbor DB configuration
+database:
+  # The password for the root user of Harbor DB. Change this before any production use.
+  password: {{ db_password_gen.stdout }}
+  # The maximum number of connections in the idle connection pool. If it <=0, no idle connections are retained.
+  max_idle_conns: 50
+  # The maximum number of open connections to the database. If it <= 0, then there is no limit on the number of open connections.
+  # Note: the default number of connections is 100 for postgres.
+  max_open_conns: 100
+
+# The default data volume
+data_volume: /data
+
+# Harbor Storage settings by default is using /data dir on local filesystem
+# Uncomment storage_service setting If you want to using external storage
+# storage_service:
+#   # ca_bundle is the path to the custom root ca certificate, which will be injected into the truststore
+#   # of registry's and chart repository's containers.  This is usually needed when the user hosts a internal storage with self signed certificate.
+#   ca_bundle:
+
+#   # storage backend, default is filesystem, options include filesystem, azure, gcs, s3, swift and oss
+#   # for more info about this configuration please refer https://docs.docker.com/registry/configuration/
+#   filesystem:
+#     maxthreads: 100
+#   # set disable to true when you want to disable registry redirect
+#   redirect:
+#     disabled: false
+
+# Clair configuration
+clair:
+  # The interval of clair updaters, the unit is hour, set to 0 to disable the updaters.
+  updaters_interval: 12
+
+jobservice:
+  # Maximum number of job workers in job service
+  max_job_workers: 10
+
+notification:
+  # Maximum retry count for webhook job
+  webhook_job_max_retry: 10
+
+chart:
+  # Change the value of absolute_url to enabled can enable absolute url in chart
+  absolute_url: disabled
+
+# Log configurations
+log:
+  # options are debug, info, warning, error, fatal
+  level: info
+  # configs for logs in local storage
+  local:
+    # Log files are rotated log_rotate_count times before being removed. If count is 0, old versions are removed rather than rotated.
+    rotate_count: 50
+    # Log files are rotated only if they grow bigger than log_rotate_size bytes. If size is followed by k, the size is assumed to be in kilobytes.
+    # If the M is used, the size is in megabytes, and if G is used, the size is in gigabytes. So size 100, size 100k, size 100M and size 100G
+    # are all valid.
+    rotate_size: 200M
+    # The directory on your host that store log
+    location: /var/log/harbor
+
+  # Uncomment following lines to enable external syslog endpoint.
+  # external_endpoint:
+  #   # protocol used to transmit log to external endpoint, options is tcp or udp
+  #   protocol: tcp
+  #   # The host of external endpoint
+  #   host: localhost
+  #   # Port of external endpoint
+  #   port: 5140
+
+#This attribute is for migrator to detect the version of the .cfg file, DO NOT MODIFY!
+_version: 1.9.0
+
+# Uncomment external_database if using external database.
+# external_database:
+#   harbor:
+#     host: harbor_db_host
+#     port: harbor_db_port
+#     db_name: harbor_db_name
+#     username: harbor_db_username
+#     password: harbor_db_password
+#     ssl_mode: disable
+#     max_idle_conns: 2
+#     max_open_conns: 0
+#   clair:
+#     host: clair_db_host
+#     port: clair_db_port
+#     db_name: clair_db_name
+#     username: clair_db_username
+#     password: clair_db_password
+#     ssl_mode: disable
+#   notary_signer:
+#     host: notary_signer_db_host
+#     port: notary_signer_db_port
+#     db_name: notary_signer_db_name
+#     username: notary_signer_db_username
+#     password: notary_signer_db_password
+#     ssl_mode: disable
+#   notary_server:
+#     host: notary_server_db_host
+#     port: notary_server_db_port
+#     db_name: notary_server_db_name
+#     username: notary_server_db_username
+#     password: notary_server_db_password
+#     ssl_mode: disable
+
+# Uncomment external_redis if using external Redis server
+# external_redis:
+#   host: redis
+#   port: 6379
+#   password:
+#   # db_index 0 is for core, it's unchangeable
+#   registry_db_index: 1
+#   jobservice_db_index: 2
+#   chartmuseum_db_index: 3
+
+# Uncomment uaa for trusting the certificate of uaa instance that is hosted via self-signed cert.
+# uaa:
+#   ca_file: /path/to/ca
+
+# Global proxy
+# Config http proxy for components, e.g. http://my.proxy.com:3128
+# Components doesn't need to connect to each others via http proxy.
+# Remove component from `components` array if want disable proxy
+# for it. If you want use proxy for replication, MUST enable proxy
+# for core and jobservice, and set `http_proxy` and `https_proxy`.
+# Add domain to the `no_proxy` field, when you want disable proxy
+# for some special registry.
+proxy:
+  http_proxy:
+  https_proxy:
+  no_proxy: 127.0.0.1,localhost,.local,.internal,log,db,redis,nginx,core,portal,postgresql,jobservice,registry,registryctl,clair
+  components:
+    - core
+    - jobservice
+    - clair


### PR DESCRIPTION
你好，对 harbor 的安装脚本做了一点改进，具体有3点
1）增加对 harbor v1.8-v1.10 新版本的支持
2）支持使用正式证书安装，通过 SELF_SIGNED_CERT=(yes/no) 参数实现，no 的话需提前把证书命名为harbor.pem 和 harbor-key.pem 放在 down 目录下。
3）默认密码改为随机生成，密码会配置在 harbor.cfg 或 harbor.yml 下，避免公共网络下使用默认密码的安全隐患。