### PR TITLE
修复kube-router报错

### DIFF
--- a/roles/kube-router/templates/kuberouter.yaml.j2
+++ b/roles/kube-router/templates/kuberouter.yaml.j2
@@ -34,6 +34,9 @@ metadata:
   name: kube-router
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-router
   template:
     metadata:
       labels:


### PR DESCRIPTION
安装kube-router时，报以下错误：
```
error validating data: ValidationError(DaemonSet.spec): missing required field "selector" in io.k8s.api.apps.v1.DaemonSetSpec; if you choose to ignore these errors, turn validation off with --validate=false
```
缺少 DaemonSet.spec.selector