### PR TITLE
Update test.yaml

### DIFF
--- a/manifests/storage/test.yaml
+++ b/manifests/storage/test.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: test-claim
 spec:
-  storageClassName: nfs-dynamic-class-01
+  storageClassName: nfs-dynamic-class
   accessModes:
     - ReadWriteMany
   resources:


### PR DESCRIPTION
fix storageClassName: nfs-dynamic-class-01和
roles/cluster-storage/defaults/main.yml中定义的  storage_class: "nfs-dynamic-class"不一致
[#827]