### PR TITLE
fix: 修复dashboard只读账号登录时提示无权限查看secrets问题

### DIFF
--- a/manifests/dashboard/read-user-sa-rbac.yaml
+++ b/manifests/dashboard/read-user-sa-rbac.yaml
@@ -39,6 +39,7 @@ rules:
   - serviceaccounts
   - services
   - services/status
+  - secrets
   verbs:
   - get
   - list


### PR DESCRIPTION
解决只读账号登录dashboard 右上角不断有消息提示无权限查看secrets问题