### PR TITLE
roles/calico/defaults/main.yaml 增加 CALICO_NETWORKING_BACKEND 变量

### DIFF
--- a/roles/calico/defaults/main.yml
+++ b/roles/calico/defaults/main.yml
@@ -14,6 +14,9 @@ FELIX_LOG_LVL: "warning"
 #IP_AUTODETECTION_METHOD: "interface=eth0"
 IP_AUTODETECTION_METHOD: "can-reach={{ groups['kube-master'][0] }}"
 
+# 设置calico 网络 backend: brid, vxlan, none
+CALICO_NETWORKING_BACKEND: "brid"
+
 # 更新支持calico 版本: [v3.3.x] [v3.4.x] [v3.8.x]
 calicoVer: "v3.8.8"
 calico_ver: "{{ calicoVer }}"

--- a/roles/calico/templates/calico-v3.3.yaml.j2
+++ b/roles/calico/templates/calico-v3.3.yaml.j2
@@ -21,7 +21,7 @@ data:
   etcd_cert: "/calico-secrets/etcd-cert"
   etcd_key: "/calico-secrets/etcd-key"
   # Configure the Calico backend to use.
-  calico_backend: "bird"
+  calico_backend: "{{ CALICO_NETWORKING_BACKEND }}"
 
   # Configure the MTU to use
   veth_mtu: "1440"

--- a/roles/calico/templates/calico-v3.4.yaml.j2
+++ b/roles/calico/templates/calico-v3.4.yaml.j2
@@ -21,7 +21,7 @@ data:
   etcd_cert: "/calico-secrets/etcd-cert"
   etcd_key: "/calico-secrets/etcd-key"
   # Configure the Calico backend to use.
-  calico_backend: "bird"
+  calico_backend: "{{ CALICO_NETWORKING_BACKEND }}"
 
   # Configure the MTU to use
   veth_mtu: "1440"

--- a/roles/calico/templates/calico-v3.8.yaml.j2
+++ b/roles/calico/templates/calico-v3.8.yaml.j2
@@ -22,7 +22,7 @@ data:
   # Typha is disabled.
   typha_service_name: "none"
   # Configure the backend to use.
-  calico_backend: "bird"
+  calico_backend: "{{ CALICO_NETWORKING_BACKEND }}"
 
   # Configure the MTU to use
   veth_mtu: "1440"


### PR DESCRIPTION
ConfigMap中的calico_backend可以灵活根据calico官方的 CALICO_NETWORKING_BACKEND Environment Variables 配置不同的backend mode