### PR TITLE
**Debian 10** 默认 `iptables` 使用 `nf_tables`,

### DIFF
--- a/roles/prepare/tasks/ubuntu.yml
+++ b/roles/prepare/tasks/ubuntu.yml
@@ -43,3 +43,11 @@
 
 - name: 重启 journald 服务
   service: name=systemd-journald state=restarted
+
+- name: Configuration iptables
+  shell: 'iptables -F \
+    && iptables -t nat -F \
+    && iptables -t mangle -F \
+    && iptables -X \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy'
+  when: ansible_distribution == "Debian" and ansible_distribution_version|int >= 10


### PR DESCRIPTION
**Debian 10** 默认 `iptables` 使用 `nf_tables`, 会导致很多的网络问题，不管使用什么网络插件，需将 `iptables` 改为使用传统的方式

## 相关 issues：
- https://github.com/kubernetes/kubernetes/issues/82361
- https://github.com/kubernetes/kubernetes/issues/71305
