### PR TITLE
修复 calico 网络 backend 设置为 vxlan none 时，calico 部署失败

### DIFF
--- a/roles/calico/templates/calico-v3.15.yaml.j2
+++ b/roles/calico/templates/calico-v3.15.yaml.j2
@@ -363,7 +363,9 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
+{% if CALICO_NETWORKING_BACKEND == "brid" %}
               - -bird-live
+{% endif %}
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -372,7 +374,9 @@ spec:
               command:
               - /bin/calico-node
               - -felix-ready
+{% if CALICO_NETWORKING_BACKEND == "brid" %}
               - -bird-ready
+{% endif %}
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules

--- a/roles/calico/templates/calico-v3.3.yaml.j2
+++ b/roles/calico/templates/calico-v3.3.yaml.j2
@@ -206,8 +206,10 @@ spec:
             exec:
               command:
               - /bin/calico-node
-              - -bird-ready
               - -felix-ready
+{% if CALICO_NETWORKING_BACKEND == "brid" %}
+              - -bird-ready
+{% endif %}
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules

--- a/roles/calico/templates/calico-v3.4.yaml.j2
+++ b/roles/calico/templates/calico-v3.4.yaml.j2
@@ -244,8 +244,10 @@ spec:
             exec:
               command:
               - /bin/calico-node
-              - -bird-ready
               - -felix-ready
+{% if CALICO_NETWORKING_BACKEND == "brid" %}
+              - -bird-ready
+{% endif %}
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules

--- a/roles/calico/templates/calico-v3.8.yaml.j2
+++ b/roles/calico/templates/calico-v3.8.yaml.j2
@@ -337,7 +337,9 @@ spec:
               command:
                 - /bin/calico-node
                 - -felix-live
+{% if CALICO_NETWORKING_BACKEND == "brid" %}
                 - -bird-live
+{% endif %}
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -345,8 +347,10 @@ spec:
             exec:
               command:
               - /bin/calico-node
-              - -bird-ready
               - -felix-ready
+{% if CALICO_NETWORKING_BACKEND == "brid" %}
+              - -bird-ready
+{% endif %}
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules


### PR DESCRIPTION
当 CALICO_NETWORKING_BACKEND 设置为 vxlan,none 时, readiness/liveness 会一直检测失败。

### 参考
- https://docs.projectcalico.org/getting-started/kubernetes/installation/config-options