### PR TITLE
# 判断服务状态直接使用systemctl is-active；避免使用grep

### DIFF
--- a/roles/chrony/tasks/main.yml
+++ b/roles/chrony/tasks/main.yml
@@ -41,9 +41,9 @@
   tags: restart_chronyd
 
 - name: 以轮询的方式等待chronyd服务启动
-  shell: "systemctl status chronyd.service|grep Active"
+  shell: "systemctl is-active chronyd.service"
   register: svc_status
-  until: '"running" in svc_status.stdout'
+  until: '"active" in svc_status.stdout'
   retries: 3
   delay: 3
   tags: restart_chronyd

--- a/roles/cluster-restore/tasks/main.yml
+++ b/roles/cluster-restore/tasks/main.yml
@@ -30,8 +30,8 @@
   service: name=etcd state=restarted
 
 - name: 以轮询的方式等待服务同步完成
-  shell: "systemctl status etcd.service|grep Active"
+  shell: "systemctl is-active etcd.service"
   register: etcd_status
-  until: '"running" in etcd_status.stdout'
+  until: '"active" in etcd_status.stdout'
   retries: 8
   delay: 8

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -1,14 +1,14 @@
 - name: 获取是否已经安装docker
-  shell: 'systemctl status docker|grep Active || echo "NOT FOUND"'
+  shell: 'systemctl is-active docker || echo "NOT FOUND"'
   register: docker_status
 
 - name: WARNNING 提示
   debug:
     msg: "[WARN]: docker is running, and containerd will be installed" 
-  when: '"running" in docker_status.stdout'
+  when: '"active" in docker_status.stdout'
 
 - name: 获取是否已经安装containerd
-  shell: 'systemctl status containerd|grep Active || echo "NoFound"'
+  shell: 'systemctl is-active containerd || echo "NoFound"'
   register: containerd_svc
 
 - block:
@@ -53,9 +53,9 @@
       tags: upgrade
 
     - name: 轮询等待containerd服务运行
-      shell: "systemctl status containerd.service|grep Active"
+      shell: "systemctl is-active containerd.service"
       register: containerd_status
-      until: '"running" in containerd_status.stdout'
+      until: '"active" in containerd_status.stdout'
       retries: 8
       delay: 2
       tags: upgrade

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: 获取是否已经安装docker
-  shell: 'systemctl status docker|grep Active || echo "NoFound"'
+  shell: 'systemctl is-active docker || echo "NoFound"'
   register: docker_svc
 
 - name: 获取是否已经安装containerd
-  shell: 'systemctl status containerd|grep Active || echo "NoFound"'
+  shell: 'systemctl is-active containerd || echo "NoFound"'
   register: containerd_svc
 
 # 18.09.x 版本二进制名字有变化，需要做判断
@@ -102,9 +102,9 @@
       tags: upgrade_docker
 
     - name: 轮询等待docker服务运行
-      shell: "systemctl status docker.service|grep Active"
+      shell: "systemctl is-active docker.service"
       register: docker_status
-      until: '"running" in docker_status.stdout'
+      until: '"active" in docker_status.stdout'
       retries: 8
       delay: 2
       tags: upgrade_docker

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -41,9 +41,9 @@
   tags: upgrade_etcd, restart_etcd
 
 - name: 以轮询的方式等待服务同步完成
-  shell: "systemctl status etcd.service|grep Active"
+  shell: "systemctl is-active etcd.service"
   register: etcd_status
-  until: '"running" in etcd_status.stdout'
+  until: '"active" in etcd_status.stdout'
   retries: 8
   delay: 8
   tags: upgrade_etcd, restart_etcd

--- a/roles/ex-lb/tasks/main.yml
+++ b/roles/ex-lb/tasks/main.yml
@@ -37,9 +37,9 @@
   tags: restart_lb
 
 - name: 以轮询的方式等待l4lb服务启动
-  shell: "systemctl status l4lb.service|grep Active"
+  shell: "systemctl is-active l4lb.service"
   register: svc_status
-  until: '"running" in svc_status.stdout'
+  until: '"active" in svc_status.stdout'
   retries: 3
   delay: 3
   tags: restart_lb
@@ -72,9 +72,9 @@
   tags: restart_lb
 
 - name: 以轮询的方式等待keepalived服务启动
-  shell: "systemctl status keepalived.service|grep Active"
+  shell: "systemctl is-active keepalived.service"
   register: svc_status
-  until: '"running" in svc_status.stdout'
+  until: '"active" in svc_status.stdout'
   retries: 3
   delay: 3
   tags: restart_lb

--- a/roles/kube-lb/tasks/main.yml
+++ b/roles/kube-lb/tasks/main.yml
@@ -26,9 +26,9 @@
   tags: restart_kube-lb
 
 - name: 以轮询的方式等待kube-lb服务启动
-  shell: "systemctl status kube-lb.service|grep Active"
+  shell: "systemctl is-active kube-lb.service"
   register: svc_status
-  until: '"running" in svc_status.stdout'
+  until: '"active" in svc_status.stdout'
   retries: 3
   delay: 3
   tags: restart_kube-lb

--- a/roles/kube-master/tasks/main.yml
+++ b/roles/kube-master/tasks/main.yml
@@ -86,27 +86,27 @@
 
 # 轮询等待kube-apiserver启动完成
 - name: 轮询等待kube-apiserver启动
-  shell: "systemctl status kube-apiserver.service|grep Active"
+  shell: "systemctl is-active kube-apiserver.service"
   register: api_status
-  until: '"running" in api_status.stdout'
+  until: '"active" in api_status.stdout'
   retries: 10
   delay: 3
   tags: upgrade_k8s, restart_master
 
 # 轮询等待kube-controller-manager启动完成
 - name: 轮询等待kube-controller-manager启动
-  shell: "systemctl status kube-controller-manager.service|grep Active"
+  shell: "systemctl is-active kube-controller-manager.service"
   register: cm_status
-  until: '"running" in cm_status.stdout'
+  until: '"active" in cm_status.stdout'
   retries: 8
   delay: 3
   tags: upgrade_k8s, restart_master
 
 # 轮询等待kube-scheduler启动完成
 - name: 轮询等待kube-scheduler启动
-  shell: "systemctl status kube-scheduler.service|grep Active"
+  shell: "systemctl is-active kube-scheduler.service"
   register: sch_status
-  until: '"running" in sch_status.stdout'
+  until: '"active" in sch_status.stdout'
   retries: 8
   delay: 3
   tags: upgrade_k8s, restart_master

--- a/roles/kube-node/tasks/main.yml
+++ b/roles/kube-node/tasks/main.yml
@@ -90,18 +90,18 @@
 
 # 轮询等待kube-proxy启动完成
 - name: 轮询等待kube-proxy启动
-  shell: "systemctl status kube-proxy.service|grep Active"
+  shell: "systemctl is-active kube-proxy.service"
   register: kubeproxy_status
-  until: '"running" in kubeproxy_status.stdout'
+  until: '"active" in kubeproxy_status.stdout'
   retries: 4
   delay: 2
   tags: reload-kube-proxy, upgrade_k8s, restart_node
 
 # 轮询等待kubelet启动完成
 - name: 轮询等待kubelet启动
-  shell: "systemctl status kubelet.service|grep Active"
+  shell: "systemctl is-active kubelet.service"
   register: kubelet_status
-  until: '"running" in kubelet_status.stdout'
+  until: '"active" in kubelet_status.stdout'
   retries: 4
   delay: 2
   tags: reload-kube-proxy, upgrade_k8s, restart_node


### PR DESCRIPTION
修改判断服务运行状态逻辑，避免使用grep匹配遗漏或者误匹配