### PR TITLE
添加docker的iptables开关设置

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -58,6 +58,9 @@ DOCKER_STORAGE_DIR: "/var/lib/docker"
 # [docker]开启Restful API
 ENABLE_REMOTE_API: false
 
+# [docker]开启iptables
+ENABLE_DOCKER_IPTABLES: false
+
 # [docker]信任的HTTP仓库
 INSECURE_REG: '["127.0.0.1/8"]'
 

--- a/roles/docker/templates/daemon.json.j2
+++ b/roles/docker/templates/daemon.json.j2
@@ -19,5 +19,6 @@
     "max-size": "50m",
     "max-file": "1"
     },
-  "storage-driver": "overlay2"
+  "storage-driver": "overlay2",
+  "iptables": {{ ENABLE_DOCKER_IPTABLES }}
 }


### PR DESCRIPTION
docker默认开启iptables规则，流量从docker出去，经过flannel等网络插件会做一次snat，会影响dest pod获取src pod请求的真实ip。
默认关闭docker的iptables设置，可以保证dest pod获取正确的ip地址。
功能已自测。