### PR TITLE
解决docker和kubelet默认的cgroup driver不一致导致部署失败的问题。

### DIFF
--- a/ezdown
+++ b/ezdown
@@ -157,7 +157,8 @@ EOF
     "max-size": "10m",
     "max-file": "3"
     },
-  "data-root": "/var/lib/docker"
+  "data-root": "/var/lib/docker",
+  "exec-opts": ["native.cgroupdriver=systemd"]
 }
 EOF
   else
@@ -172,7 +173,8 @@ EOF
     "max-size": "10m",
     "max-file": "3"
     },
-  "data-root": "/var/lib/docker"
+  "data-root": "/var/lib/docker",
+  "exec-opts": ["native.cgroupdriver=systemd"]
 }
 EOF
   fi


### PR DESCRIPTION
# PR解决的问题
Fixed issue #1065

# 问题描述
解决docker和kubelet默认的cgroup driver不一致导致部署失败的问题。
```shell
TASK [kube-node : 轮询等待kubelet启动] ********************************************************************************************************
fatal: [192.168.0.160]: FAILED! => {"attempts": 4, "changed": true, "cmd": "systemctl status kubelet.service|grep Active", "delta": "0:00:00.006618", "end": "2021-09-11 10:53:47.133319", "rc": 0, "start": "2021-09-11 10:53:47.126701", "stderr": "", "stderr_lines": [], "stdout": "   Active: activating (auto-restart) (Result: exit-code) since Sat 2021-09-11 10:53:42 CST; 4s ago", "stdout_lines": ["   Active: activating (auto-restart) (Result: exit-code) since Sat 2021-09-11 10:53:42 CST; 4s ago"]}

PLAY RECAP ******************************************************************************************************************************
192.168.0.160              : ok=94   changed=79   unreachable=0    failed=1    skipped=137  rescued=0    ignored=4
localhost                  : ok=34   changed=31   unreachable=0    failed=0    skipped=13   rescued=0    ignored=0


Sep 11 12:29:51 master kubelet[89348]: E0911 12:29:51.683465 89348 server.go:292] **"Failed to run kubelet" err="failed to run Kubelet: misconfiguration: kubelet cgroup driver: "systemd" is different from docker cgroup driver: "cgroupfs""**
Sep 11 12:29:51 master systemd[1]: kubelet.service: main process exited, code=exited, status=1/FAILURE
Sep 11 12:29:51 master systemd[1]: Unit kubelet.service entered failed state.
Sep 11 12:29:51 master systemd[1]: kubelet.service failed.
```
# 测试结果
```shell

TASK [cluster-addon : 创建 dashboard部署] ***************************************************************************************************
changed: [192.168.0.160]

PLAY RECAP ******************************************************************************************************************************
192.168.0.160              : ok=131  changed=83   unreachable=0    failed=0    skipped=260  rescued=0    ignored=4
localhost 
```



