### PR TITLE
修改文档里面grafana的默认密码

### DIFF
--- a/docs/guide/prometheus.md
+++ b/docs/guide/prometheus.md
@@ -46,7 +46,7 @@ service/prometheus-prometheus-node-exporter       ClusterIP   10.68.64.56     <n
 
 - 访问prometheus的web界面：`http://$NodeIP:30901`
 - 访问alertmanager的web界面：`http://$NodeIP:30902`
-- 访问grafana的web界面：`http://$NodeIP:30903` (默认用户密码 admin:admin)
+- 访问grafana的web界面：`http://$NodeIP:30903` (默认用户密码 admin:Admin1234!)
 
 ## 管理操作
 


### PR DESCRIPTION
文档里面的密码过时了，安装后无法登录grafana，通过进入容器后查询到的默认密码。请通过合并，让后来使用的人可以直接登录。