### PR TITLE
Add docker proxy config at ezdown

### DIFF
--- a/ezdown
+++ b/ezdown
@@ -177,6 +177,31 @@ EOF
 EOF
   fi
 
+  # docker proxy setting
+  http_proxy=${http_proxy:-}
+  HTTP_PROXY=${HTTP_PROXY:-$http_proxy}
+  https_proxy=${https_proxy:-}
+  HTTPS_PROXY=${HTTPS_PROXY:-$https_proxy}
+  USE_PROXY=0
+  CONFIG="[Service]\n"
+
+  if [[ ! -z ${HTTP_PROXY} ]]; then
+    USE_PROXY=1
+    CONFIG=${CONFIG}"Environment=HTTP_PROXY=${HTTP_PROXY}\n"
+  fi
+  if [[ ! -z ${HTTPS_PROXY} ]]; then
+    USE_PROXY=1
+    CONFIG=${CONFIG}"Environment=HTTPS_PROXY=${HTTPS_PROXY}\n"
+  fi
+  if [[ ${USE_PROXY} == 1 ]]; then
+    logger debug "generate docker service http proxy file"
+    mkdir -p /etc/systemd/system/docker.service.d
+    c=$(echo -e ${CONFIG})
+    cat > /etc/systemd/system/docker.service.d/http-proxy.conf << EOF
+${c}
+EOF
+  fi
+
   if [[ -e /etc/centos-release || -e /etc/redhat-release ]]; then
     logger debug "turn off selinux in CentOS/Redhat"
     getenforce|grep Disabled || setenforce 0


### PR DESCRIPTION
**What this PR does / why we need it:**

在企业内网环境内需要通过代理服务器访问外网，ezdown的`download_docker()`函数能够感知用户设置的`HTTP_PROXY`, `HTTPS_PROXY`环境变量来影响`curl`或者`wget`命令正确下载安装docker，但是`get_kubeasz()`函数调用`docker pull`命令下载镜像的时候却不会使用到这些配置，因此需要额外配置docker服务使代理生效。

refer: https://docs.docker.com/config/daemon/systemd/#httphttps-proxy
