### PR TITLE
未运行'ezdown -D'之前运行'ezdown -P/R'会遗留容器导致再次运行失败

### DIFF
--- a/ezdown
+++ b/ezdown
@@ -259,6 +259,7 @@ function get_ext_bin() {
 function get_sys_pkg() {
   [[ -f "$BASE/down/packages/chrony_xenial.tar.gz" ]] && { logger warn "system packages existed"; return 0; }
 
+  docker ps -a |grep temp_sys_pkg && { logger debug "remove existing container"; docker rm -f temp_sys_pkg; }
   logger info "downloading system packages kubeasz-sys-pkg:$SYS_PKG_VER"
   docker pull "easzlab/kubeasz-sys-pkg:$SYS_PKG_VER" && \
   logger debug "run a temporary container" && \
@@ -272,6 +273,7 @@ function get_sys_pkg() {
 function get_harbor_offline_pkg() {
   [[ -f "$BASE/down/harbor-offline-installer-$HARBOR_VER.tgz" ]] && { logger warn "harbor-offline existed"; return 0; }
 
+  docker ps -a |grep temp_harbor && { logger debug "remove existing container"; docker rm -f temp_harbor; }
   logger info "downloading harbor-offline:$HARBOR_VER"
   docker pull "easzlab/harbor-offline:$HARBOR_VER" && \
   logger debug "run a temporary container" && \

--- a/ezdown
+++ b/ezdown
@@ -393,7 +393,7 @@ function main() {
   BASE="/etc/kubeasz"
 
   # check if use bash shell
-  readlink /proc/$$/exe|grep -q "dash" && { logger error "you should use bash shell, not sh"; exit 1; }
+  readlink /proc/$$/exe|grep -q "bash" || { logger error "you should use bash shell, not sh"; exit 1; }
   # check if use with root
   [[ "$EUID" -ne 0 ]] && { logger error "you should run this script as root"; exit 1; }
   


### PR DESCRIPTION
未运行'ezdown -D'之前运行'ezdown -P/R'会遗留容器导致再次运行失败
在get_sys_pkg 和 get_harbor_offline_pkg 运行时首先判断是否有残留容器，若有则先清理再重新运行
---------------------------------------------------------------------------------------------------------------------------------------
readlink 检测bash应该是误写为dash