### PR TITLE
更新 roles/kube-master/main.yml 修改证书时复制新证书到Master节点

### DIFF
--- a/roles/calico/templates/calico-v3.19.yaml.j2
+++ b/roles/calico/templates/calico-v3.19.yaml.j2
@@ -43,7 +43,7 @@ data:
           "etcd_endpoints": "{{ ETCD_ENDPOINTS }}",
           "etcd_key_file": "/etc/calico/ssl/calico-key.pem",
           "etcd_cert_file": "/etc/calico/ssl/calico.pem",
-          "etcd_ca_cert_file": "/etc/kubernetes/ssl/ca.pem",
+          "etcd_ca_cert_file": "{{ ca_dir }}/ca.pem",
           "mtu": 1500,
           "ipam": {
               "type": "calico-ipam"

--- a/roles/calico/templates/calico-v3.23.yaml.j2
+++ b/roles/calico/templates/calico-v3.23.yaml.j2
@@ -46,7 +46,7 @@ data:
           "etcd_endpoints": "{{ ETCD_ENDPOINTS }}",
           "etcd_key_file": "/etc/calico/ssl/calico-key.pem",
           "etcd_cert_file": "/etc/calico/ssl/calico.pem",
-          "etcd_ca_cert_file": "/etc/kubernetes/ssl/ca.pem",
+          "etcd_ca_cert_file": "{{ ca_dir }}/ca.pem",
           "mtu": 1500,
           "ipam": {
               "type": "calico-ipam"

--- a/roles/kube-master/tasks/main.yml
+++ b/roles/kube-master/tasks/main.yml
@@ -58,6 +58,7 @@
   - kubernetes-key.pem
   - aggregator-proxy.pem
   - aggregator-proxy-key.pem
+  tags: change_cert
 
 - name: 替换 kubeconfig 的 apiserver 地址
   lineinfile:


### PR DESCRIPTION
修复文档 https://github.com/easzlab/kubeasz/blob/master/docs/op/ch_apiserver_cert.md 中第二步执行后证书 APIServer 使用的证书未更新问题。