### PR TITLE
#1187 的一点小改动

### DIFF
--- a/playbooks/94.backup.yml
+++ b/playbooks/94.backup.yml
@@ -36,7 +36,7 @@
 
   # step2: backup data on the healthy member
   - name: make a backup on the etcd node
-    shell: "mkdir -p /etcd_backup && cd /etcd_backup && \
+    shell: "mkdir -p {{ cluster_dir }}/backup/ && cd {{ cluster_dir }}/backup/ && \
         ETCDCTL_API=3 {{ bin_dir }}/etcdctl snapshot save snapshot_{{ timestamp.stdout }}.db"
     args:
       warn: false
@@ -44,7 +44,7 @@
 
   - name: fetch the backup data
     fetch:
-      src: /etcd_backup/snapshot_{{ timestamp.stdout }}.db
+      src: {{ cluster_dir }}/backup/snapshot_{{ timestamp.stdout }}.db
       dest: "{{ cluster_dir }}/backup/"
       flat: yes
     delegate_to: "{{ RUNNING_NODE.stdout }}"

--- a/roles/cluster-restore/tasks/main.yml
+++ b/roles/cluster-restore/tasks/main.yml
@@ -5,18 +5,13 @@
   file: name={{ ETCD_DATA_DIR }}/member state=absent
 
 - name: 生成备份目录
-  file: name=/etcd_backup state=directory
-
-- name: 准备指定的备份etcd 数据
-  copy: 
-    src: "{{ cluster_dir }}/backup/{{ db_to_restore }}"
-    dest: "/etcd_backup/snapshot.db"
+  file: name={{ cluster_dir }}/backup state=directory
 
 - name: 清理上次备份恢复数据
-  file: name=/etcd_backup/etcd-{{ inventory_hostname }}.etcd state=absent
+  file: name={{ cluster_dir }}/backup/etcd-{{ inventory_hostname }}.etcd state=absent
 
 - name: etcd 数据恢复
-  shell: "cd /etcd_backup && \
+  shell: "cd {{ cluster_dir }}/backup && \
 	ETCDCTL_API=3 {{ bin_dir }}/etcdctl snapshot restore snapshot.db \
 	--name etcd-{{ inventory_hostname }} \
 	--initial-cluster {{ ETCD_NODES }} \
@@ -24,7 +19,7 @@
 	--initial-advertise-peer-urls https://{{ inventory_hostname }}:2380"
 
 - name: 恢复数据至etcd 数据目录
-  shell: "cp -rf /etcd_backup/etcd-{{ inventory_hostname }}.etcd/member {{ ETCD_DATA_DIR }}/"
+  shell: "cp -rf {{ cluster_dir }}/backup/etcd-{{ inventory_hostname }}.etcd/member {{ ETCD_DATA_DIR }}/"
 
 - name: 重启etcd 服务
   service: name=etcd state=restarted

--- a/roles/etcd/clean-etcd.yml
+++ b/roles/etcd/clean-etcd.yml
@@ -14,5 +14,12 @@
     with_items:
     - {{ ETCD_DATA_DIR }}
     - {{ ETCD_WAL_DIR }}
+    - {{ cluster_dir }}/backup
     - "/backup/k8s"
     - "/etc/systemd/system/etcd.service"
+
+- name: 移除定时任务
+  cron:
+    name: "backup etcd data daily"
+    state: absent
+  

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -49,3 +49,21 @@
   retries: 8
   delay: 8
   tags: upgrade_etcd, restart_etcd
+
+- name: 创建 etcd 备份脚本
+  template: src=etcdtools.sh.j2 dest={{ cluster_dir }}/backup/etcdtools.sh
+  connection: local
+
+- name: 创建 etcd 定时任务脚本
+  template: src=etcd_backup.sh.j2 dest={{ cluster_dir }}/backup/etcd_backup.sh
+  connection: local
+
+- name: 启动 etcd 定时备份
+  cron: 
+    name: "backup etcd data daily"
+    minute: "0"
+    hour: "1"
+    job: "bash {{ cluster_dir }}/backup/etcd_backup.sh"
+  
+
+

--- a/roles/etcd/templates/etcd_backup.sh.j2
+++ b/roles/etcd/templates/etcd_backup.sh.j2
@@ -1,0 +1,5 @@
+#!/bin/bash
+# 删除 10 天以上的备份文件，并生成新的备份
+sudo find {{ cluster_dir }}/backup/ -name "snapshot*.db*" -type f -mtime +10 -exec rm {} \;
+
+bash {{ cluster_dir }}/backup/etcdtools.sh export

--- a/roles/etcd/templates/etcdtools.sh.j2
+++ b/roles/etcd/templates/etcdtools.sh.j2
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+BACKUP_DIR="{{ cluster_dir }}/backup"
+CACERT="{{ ca_dir }}/ca.pem"
+ETCD_KEY="{{ ca_dir }}/etcd-key.pem"
+ETCD_CERT="{{ ca_dir }}/etcd.pem"
+
+save_snapshot(){
+    
+    local save_dir=$1
+    if [ -z ${save_dir} ];then
+        [ ! -d "${BACKUP_DIR}" ] && mkdir -p ${BACKUP_DIR}
+        snapshot=${BACKUP_DIR}/snapshot.db
+    else
+        [ ! -d "${save_dir}" ] && mkdir -p ${save_dir}
+        snapshot=${save_dir}/snapshot.db
+    fi
+    save_file=${snapshot}-$(date +%Y%m%d%H%M%S.%N)
+    local service_file="/etc/systemd/system/etcd.service"
+    if [ ! -f "${service_file}" ];then
+        echo "[ERROR]: File ${service_file} does not exist!"
+        exit 1
+    fi
+
+    local INITIAL_CLUSTER=$(sed -n 's/.*--initial-cluster=\(.*\)/\1/p' ${service_file}|awk '{print $1}')
+	local ENDPOINTS_ARRAY=(${INITIAL_CLUSTER//,/ })
+	
+	local ETCD_NODE_ARRAY=`for ENDPOINT in ${ENDPOINTS_ARRAY[@]};do \
+	echo $ENDPOINT |awk -F '=' '{print $2}'|awk -F '//' '{print $2}' |awk -F ':' '{print $1}';\
+	done`
+	
+    local health_etcd_nodes=`for etcd_node in ${ETCD_NODE_ARRAY}; 
+	    do ETCDCTL_API=3 /etc/kubeasz/bin/etcdctl \
+		--endpoints=https://${etcd_node}:2379  \
+		--cacert={{ cluster_dir }}/ssl/ca.pem  \
+		--cert={{ cluster_dir }}/ssl/etcd.pem   \
+		--key={{ cluster_dir }}/ssl/etcd-key.pem  \
+		endpoint health  |grep "is healthy"|sed -n "1p"|cut -d: -f2|cut -d/ -f3; \
+		done;`
+	
+	health_etcd_node=`echo $health_etcd_nodes |awk -F ' ' '{print $1}'`
+			    
+    export ETCDCTL_API=3
+    {{ base_dir }}/bin/etcdctl --cert=${ETCD_CERT} --key=${ETCD_KEY} \
+        --cacert=${CACERT} --endpoints=https://${health_etcd_node}:2379  snapshot save ${save_file}
+    if [ $? -ne 0 ];then
+        echo "[ERROR]: Failed to save snapshot ${save_file}!"
+        exit 1
+    fi
+	yes |cp  ${save_file} ${snapshot}
+}  
+	
+
+
+usage(){
+
+    echo
+    echo "Script: $0" 
+    echo "Version: 1.0.0"
+
+    echo "
+Description: This script is used to back up etcd data."
+
+    echo
+    echo "Usage: "
+    echo "       `basename $0` [get][help][export][{{ base_dir }}/bin/etcdctl][import][status]"
+    echo
+    echo "       help"
+    echo "           Output help information"
+    echo
+    echo "       export  <backup dir>"
+    echo "           Export etcd snapshot file to backup directory"
+    echo
+    echo 
+    exit 0
+}
+
+
+case $1 in
+export)
+    save_snapshot $2;;
+*)
+    usage ;;
+esac


### PR DESCRIPTION

1. 修改 ectd 的备份路径为 {{ cluster_dir }}/backup/
2. 新增 etcd 定时备份脚本，文件路径 {{ cluster_dir }}/backup/
3. crontab 新增定时任务，每日凌晨1点执行备份。备份路径为 {{ cluster_dir }}/backup/，备份文件名 snapshot.db-时间戳，并用最4. 新的文件替换 snapshot.db
5. clean-etcd 会删掉新增加的操作
6. 修改 etcdctl 及证书路径 为 ansible 主控节点上对应路径，防止因 ansible 主控节点未安装 etcd 导致的备份失败
7. 同步修改 restore 的备份文件路径