### PR TITLE
修改ectd 备份命令和备份路径均在 ansible 节点

### DIFF
--- a/playbooks/94.backup.yml
+++ b/playbooks/94.backup.yml
@@ -34,20 +34,17 @@
     shell: "date +'%Y%m%d%H%M'"
     register: timestamp
 
-  # step2: backup data on the healthy member
+  # step2: backup data to the ansible node 
   - name: make a backup on the etcd node
-    shell: "mkdir -p /etcd_backup && cd /etcd_backup && \
-        ETCDCTL_API=3 {{ bin_dir }}/etcdctl snapshot save snapshot_{{ timestamp.stdout }}.db"
+    shell: "mkdir -p {{ cluster_dir }}/backup && cd {{ cluster_dir }}/backup && \
+        ETCDCTL_API=3 {{ base_dir }}/bin/etcdctl \
+              --endpoints=https://{{ RUNNING_NODE.stdout }}:2379 \
+              --cacert={{ cluster_dir }}/ssl/ca.pem \
+              --cert={{ cluster_dir }}/ssl/etcd.pem \
+              --key={{ cluster_dir }}/ssl/etcd-key.pem \
+        snapshot save snapshot_{{ timestamp.stdout }}.db"
     args:
       warn: false
-    delegate_to: "{{ RUNNING_NODE.stdout }}"
-
-  - name: fetch the backup data
-    fetch:
-      src: /etcd_backup/snapshot_{{ timestamp.stdout }}.db
-      dest: "{{ cluster_dir }}/backup/"
-      flat: yes
-    delegate_to: "{{ RUNNING_NODE.stdout }}"
 
   - name: update the latest backup
     shell: 'cd {{ cluster_dir }}/backup/ && /bin/cp -f snapshot_{{ timestamp.stdout }}.db snapshot.db'


### PR DESCRIPTION
将备份文件改为 ansible 主控节点的  {{ cluster_dir }}/backup 目录。

备份命令的 endpoint 是etcd 的一个正常节点，证书文件用的 {{ cluster_dir }}/ssl 分发的证书

 amd 和 arm 测试， ansible 节点安装 etcd 或未安装 etcd 均能正常使用