### PR TITLE
修改默认配置的 Kubernetes CA 证书

### DIFF
--- a/docs/setup/01-CA_and_prerequisite.md
+++ b/docs/setup/01-CA_and_prerequisite.md
@@ -62,7 +62,7 @@ kubernetes 系统各组件需要使用 TLS 证书对通信进行加密，使用 
 #### 创建 CA 证书签名请求 [ca-csr.json.j2](../../roles/deploy/templates/ca-csr.json.j2)
 ``` bash
 {
-  "CN": "kubernetes",
+  "CN": "kubernetes-ca",
   "key": {
     "algo": "rsa",
     "size": 2048

--- a/roles/deploy/templates/ca-csr.json.j2
+++ b/roles/deploy/templates/ca-csr.json.j2
@@ -1,5 +1,5 @@
 {
-  "CN": "kubernetes",
+  "CN": "kubernetes-ca",
   "key": {
     "algo": "rsa",
     "size": 2048


### PR DESCRIPTION
## 原因

默认签署的 Kubernetes CA 证书主体身份 *CN=kubernetes,OU=System,O=k8s,L=XS,ST=HangZhou,C=CN* 与 kube-apiserver 使用的证书主体身份 *CN=kubernetes,OU=System,O=k8s,L=XS,ST=HangZhou,C=CN* 相同。

使部分软件及编程语言尝试连接 https://kuberentes.default:443 ，认为 kube-apiserver 提供的服务器证书为自签名非 CA 证书，无法构建证书信任链。导致 SSL/TLS 握手阶段中止。

```bash
$ curl https://10.68.0.1:443 -v --cacert /etc/kubeasz/clusters/default/ssl/ca.pem
* About to connect() to 10.68.0.1 port 443 (#0)
*   Trying 10.68.0.1...
* Connected to 10.68.0.1 (10.68.0.1) port 443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
*   CAfile: /etc/kubeasz/clusters/default/ssl/ca.pem
  CApath: none
* Server certificate:
* 	subject: CN=kubernetes,OU=System,O=k8s,L=XS,ST=HangZhou,C=CN
* 	start date: 11月 23 12:43:00 2022 GMT
* 	expire date: 11月 10 12:43:00 2072 GMT
* 	common name: kubernetes
* 	issuer: CN=kubernetes,OU=System,O=k8s,L=XS,ST=HangZhou,C=CN
* NSS error -8182 (SEC_ERROR_BAD_SIGNATURE)
* Peer's certificate has an invalid signature.
* Closing connection 0
curl: (60) Peer's certificate has an invalid signature.
More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
```

## 解决方案

修改默认配置的 Kubernetes CA 证书的 Common Name (CN)

效果如下

```bash
$ curl https://10.68.0.1:443 -v --cacert /etc/kubeasz/clusters/default/ssl/ca.pem
* About to connect() to 10.68.0.1 port 443 (#0)
*   Trying 10.68.0.1...
* Connected to 10.68.0.1 (10.68.0.1) port 443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
*   CAfile: /etc/kubeasz/clusters/default/ssl/ca.pem
  CApath: none
* NSS: client certificate not found (nickname not specified)
* SSL connection using TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
* Server certificate:
* 	subject: CN=kubernetes,OU=System,O=k8s,L=XS,ST=HangZhou,C=CN
* 	start date: 11月 23 12:05:00 2022 GMT
* 	expire date: 11月 10 12:05:00 2072 GMT
* 	common name: kubernetes
* 	issuer: CN=kubernetes-ca,OU=System,O=k8s,L=XS,ST=HangZhou,C=CN
> GET / HTTP/1.1
> User-Agent: curl/7.29.0
> Host: 10.68.0.1
> Accept: */*
>
< HTTP/1.1 401 Unauthorized
< Audit-Id: 14c3ea27-7922-4256-a4ff-89f7308422dc
< Cache-Control: no-cache, private
< Content-Type: application/json
< Date: Wed, 23 Nov 2022 12:12:03 GMT
< Content-Length: 157
<
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "Unauthorized",
  "reason": "Unauthorized",
  "code": 401
* Connection #0 to host 10.68.0.1 left intact
}
```