### PR TITLE
检测  ex-lb 的 kube-apiserver 是否正常

### DIFF
--- a/roles/ex-lb/tasks/main.yml
+++ b/roles/ex-lb/tasks/main.yml
@@ -78,3 +78,18 @@
   retries: 3
   delay: 3
   tags: restart_lb
+
+- name: 检查 ex-lb 的 kube-apiserver 是否正常
+  uri:
+    url: "https://{{ EX_APISERVER_VIP }}:{{ EX_APISERVER_PORT }}"
+    validate_certs: no
+    client_cert: "{{ cluster_dir }}/ssl/admin.pem"
+    client_key: "{{ cluster_dir }}/ssl/admin-key.pem"
+  register: result
+  until: result.status == 200
+  retries: 2
+  delay: 5
+  run_once: true
+  connection: local
+
+# - debug: var="result"


### PR DESCRIPTION
TASK [ex-lb : 检测 kube-lb 的 kube-apiserver 是否正常] *****************************************************************************
ok: [172.20.19.28]

TASK [ex-lb: debug] ********************************************************************************************************
ok: [172.20.19.28] => {
    "result": {
        "attempts": 1,
        "audit_id": "9b1b5143-ea3f-4dc2-bbe3-1776c860bf9d",
        "cache_control": "no-cache, private",
        "changed": false,
        "connection": "close",
        "content_type": "application/json",
        "cookies": {},
        "cookies_string": "",
        "date": "Tue, 20 Dec 2022 02:45:09 GMT",
        "elapsed": 0,
        "failed": false,
        "json": {
            "paths": [
                "/.well-known/openid-configuration",
                "/api",
                "/api/v1",
                "/apis",
                "/apis/",
                "/apis/admissionregistration.k8s.io",
                "/apis/admissionregistration.k8s.io/v1",
                "/apis/apiextensions.k8s.io",
                "/apis/apiextensions.k8s.io/v1",
                "/apis/apiregistration.k8s.io",
                "/apis/apiregistration.k8s.io/v1",
                "/apis/apps",
                "/apis/apps/v1",
                "/apis/authentication.k8s.io",
                "/apis/authentication.k8s.io/v1",
                "/apis/authorization.k8s.io",
                "/apis/authorization.k8s.io/v1",
                "/apis/autoscaling",
                "/apis/autoscaling/v1",
                "/apis/autoscaling/v2",
                "/apis/autoscaling/v2beta2",
                "/apis/batch",
                "/apis/batch/v1",
                "/apis/ceph.rook.io",
                "/apis/ceph.rook.io/v1",
                "/apis/certificates.k8s.io",
                "/apis/certificates.k8s.io/v1",
                "/apis/coordination.k8s.io",
                "/apis/coordination.k8s.io/v1",
                "/apis/discovery.k8s.io",
                "/apis/discovery.k8s.io/v1",
                "/apis/events.k8s.io",
                "/apis/events.k8s.io/v1",
                "/apis/flowcontrol.apiserver.k8s.io",
                "/apis/flowcontrol.apiserver.k8s.io/v1beta1",
                "/apis/flowcontrol.apiserver.k8s.io/v1beta2",
                "/apis/metrics.k8s.io",
                "/apis/metrics.k8s.io/v1beta1",
                "/apis/monitoring.coreos.com",
                "/apis/monitoring.coreos.com/v1",
                "/apis/monitoring.coreos.com/v1alpha1",
                "/apis/networking.k8s.io",
                "/apis/networking.k8s.io/v1",
                "/apis/node.k8s.io",
                "/apis/node.k8s.io/v1",
                "/apis/objectbucket.io",
                "/apis/objectbucket.io/v1alpha1",
                "/apis/policy",
                "/apis/policy/v1",
                "/apis/rbac.authorization.k8s.io",
                "/apis/rbac.authorization.k8s.io/v1",
                "/apis/scheduling.k8s.io",
                "/apis/scheduling.k8s.io/v1",
                "/apis/storage.k8s.io",
                "/apis/storage.k8s.io/v1",
                "/apis/storage.k8s.io/v1beta1",
                "/healthz",
                "/healthz/autoregister-completion",
                "/healthz/etcd",
                "/healthz/log",
                "/healthz/ping",
                "/healthz/poststarthook/aggregator-reload-proxy-client-cert",
                "/healthz/poststarthook/apiservice-openapi-controller",
                "/healthz/poststarthook/apiservice-openapiv3-controller",
                "/healthz/poststarthook/apiservice-registration-controller",
                "/healthz/poststarthook/apiservice-status-available-controller",
                "/healthz/poststarthook/bootstrap-controller",
                "/healthz/poststarthook/crd-informer-synced",
                "/healthz/poststarthook/generic-apiserver-start-informers",
                "/healthz/poststarthook/kube-apiserver-autoregistration",
                "/healthz/poststarthook/priority-and-fairness-config-consumer",
                "/healthz/poststarthook/priority-and-fairness-config-producer",
                "/healthz/poststarthook/priority-and-fairness-filter",
                "/healthz/poststarthook/rbac/bootstrap-roles",
                "/healthz/poststarthook/scheduling/bootstrap-system-priority-classes",
                "/healthz/poststarthook/start-apiextensions-controllers",
                "/healthz/poststarthook/start-apiextensions-informers",
                "/healthz/poststarthook/start-cluster-authentication-info-controller",
                "/healthz/poststarthook/start-kube-aggregator-informers",
                "/healthz/poststarthook/start-kube-apiserver-admission-initializer",
                "/healthz/poststarthook/storage-object-count-tracker-hook",
                "/livez",
                "/livez/autoregister-completion",
                "/livez/etcd",
                "/livez/log",
                "/livez/ping",
                "/livez/poststarthook/aggregator-reload-proxy-client-cert",
                "/livez/poststarthook/apiservice-openapi-controller",
                "/livez/poststarthook/apiservice-openapiv3-controller",
                "/livez/poststarthook/apiservice-registration-controller",
                "/livez/poststarthook/apiservice-status-available-controller",
                "/livez/poststarthook/bootstrap-controller",
                "/livez/poststarthook/crd-informer-synced",
                "/livez/poststarthook/generic-apiserver-start-informers",
                "/livez/poststarthook/kube-apiserver-autoregistration",
                "/livez/poststarthook/priority-and-fairness-config-consumer",
                "/livez/poststarthook/priority-and-fairness-config-producer",
                "/livez/poststarthook/priority-and-fairness-filter",
                "/livez/poststarthook/rbac/bootstrap-roles",
                "/livez/poststarthook/scheduling/bootstrap-system-priority-classes",
                "/livez/poststarthook/start-apiextensions-controllers",
                "/livez/poststarthook/start-apiextensions-informers",
                "/livez/poststarthook/start-cluster-authentication-info-controller",
                "/livez/poststarthook/start-kube-aggregator-informers",
                "/livez/poststarthook/start-kube-apiserver-admission-initializer",
                "/livez/poststarthook/storage-object-count-tracker-hook",
                "/logs",
                "/metrics",
                "/openapi/v2",
                "/openapi/v3",
                "/openapi/v3/",
                "/openid/v1/jwks",
                "/readyz",
                "/readyz/autoregister-completion",
                "/readyz/etcd",
                "/readyz/etcd-readiness",
                "/readyz/informer-sync",
                "/readyz/log",
                "/readyz/ping",
                "/readyz/poststarthook/aggregator-reload-proxy-client-cert",
                "/readyz/poststarthook/apiservice-openapi-controller",
                "/readyz/poststarthook/apiservice-openapiv3-controller",
                "/readyz/poststarthook/apiservice-registration-controller",
                "/readyz/poststarthook/apiservice-status-available-controller",
                "/readyz/poststarthook/bootstrap-controller",
                "/readyz/poststarthook/crd-informer-synced",
                "/readyz/poststarthook/generic-apiserver-start-informers",
                "/readyz/poststarthook/kube-apiserver-autoregistration",
                "/readyz/poststarthook/priority-and-fairness-config-consumer",
                "/readyz/poststarthook/priority-and-fairness-config-producer",
                "/readyz/poststarthook/priority-and-fairness-filter",
                "/readyz/poststarthook/rbac/bootstrap-roles",
                "/readyz/poststarthook/scheduling/bootstrap-system-priority-classes",
                "/readyz/poststarthook/start-apiextensions-controllers",
                "/readyz/poststarthook/start-apiextensions-informers",
                "/readyz/poststarthook/start-cluster-authentication-info-controller",
                "/readyz/poststarthook/start-kube-aggregator-informers",
                "/readyz/poststarthook/start-kube-apiserver-admission-initializer",
                "/readyz/poststarthook/storage-object-count-tracker-hook",
                "/readyz/shutdown",
                "/version"
            ]
        },
        "msg": "OK (unknown bytes)",
        "redirected": false,
        "status": 200,
        "transfer_encoding": "chunked",
        "url": "https://172.20.19.10:8443",
        "x_kubernetes_pf_flowschema_uid": "b5902869-f7ab-4be2-ba60-0f0f8d70c360",
        "x_kubernetes_pf_prioritylevel_uid": "e2d70d07-0f73-4348-99a4-170448a42a11"
    }
}

