### PR TITLE
bugfix: containerd kubelet config

### DIFF
--- a/roles/kube-node/templates/kubelet.service.j2
+++ b/roles/kube-node/templates/kubelet.service.j2
@@ -30,6 +30,7 @@ ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/hugetlb/system.slice
 ExecStart={{ bin_dir }}/kubelet \
   --config=/var/lib/kubelet/config.yaml \
   --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+  --container-runtime=remote \
   --hostname-override={{ K8S_NODENAME }} \
   --kubeconfig=/etc/kubernetes/kubelet.kubeconfig \
   --root-dir={{ KUBELET_ROOT_DIR }} \


### PR DESCRIPTION
当选择 containerd 作为容器运行时，kubelet 配置会因缺少 `--container-runtime=remote` 导致 kubelet 启动失败，修复之