### PR TITLE
metrics-server 新增hostNetwork: true

### DIFF
--- a/roles/cluster-addon/templates/metrics-server/components.yaml.j2
+++ b/roles/cluster-addon/templates/metrics-server/components.yaml.j2
@@ -182,6 +182,7 @@ spec:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
+      hostNetwork: true
       volumes:
       - emptyDir: {}
         name: tmp-dir


### PR DESCRIPTION
今天，当我使用kubectl top nodes 来检查节点负载时，我得到了一个错误："error: Metrics API not available."
我使用了kubectl logs -f -n kube-system metrics-server-xxxxxx 和 systemctl status kube-apiserver-Service -l 查看日志，发现有很多访问失败的记录。
起初我一直认为rbac设置不正确。
经过仔细研究，我们发现是metrics-server端口不可访问。kube-apiserver和metrics-server都会报告如下错误。
909 available_controller. go:460] v1beta1.metrics.k8s. io failed with: failing or missing response from https://172.20.196.137:4443/apis/metrics.k8s.io/v1beta1: Get "https://172.20.196.137:4443/apis/metrics.k8s. io/v1beta1": context deadline exceeded
最后，我修改metrics server启动YAML文件：deployment.spec.template.spec.hostNetwork: true
发现问题已经解决。