### PR TITLE
fix: CLUSTER_DNS_SVC_IP & CLUSTER_KUBERNETES_SVC_IP ip concat  error

### DIFF
--- a/roles/cluster-addon/vars/main.yml
+++ b/roles/cluster-addon/vars/main.yml
@@ -1,4 +1,4 @@
 # default values
 
 # coredns 服务地址，根据SERVICE_CIDR 设置，默认选择网段第二个地址
-CLUSTER_DNS_SVC_IP: "{{ SERVICE_CIDR.split('.')[0] }}.{{ SERVICE_CIDR.split('.')[1] }}.{{ SERVICE_CIDR.split('.')[2] }}.{{ SERVICE_CIDR.split('.')[3]|int + 2 }}"
+CLUSTER_DNS_SVC_IP: "{{ SERVICE_CIDR.split('.')[0] }}.{{ SERVICE_CIDR.split('.')[1] }}.{{ SERVICE_CIDR.split('.')[2] }}.{{ SERVICE_CIDR.split('.')[3]|regex_replace('/.*', '')|int + 2 }}"

--- a/roles/kube-master/vars/main.yml
+++ b/roles/kube-master/vars/main.yml
@@ -3,4 +3,4 @@ TMP_ENDPOINTS: "{% for h in groups['etcd'] %}https://{{ h }}:2379,{% endfor %}"
 ETCD_ENDPOINTS: "{{ TMP_ENDPOINTS.rstrip(',') }}"
 
 # kubernetes.default.svc 地址根据SERVICE_CIDR 设置为网段的第一个地址
-CLUSTER_KUBERNETES_SVC_IP: "{{ SERVICE_CIDR.split('.')[0] }}.{{ SERVICE_CIDR.split('.')[1] }}.{{ SERVICE_CIDR.split('.')[2] }}.{{ SERVICE_CIDR.split('.')[3]|int + 1 }}"
+CLUSTER_KUBERNETES_SVC_IP: "{{ SERVICE_CIDR.split('.')[0] }}.{{ SERVICE_CIDR.split('.')[1] }}.{{ SERVICE_CIDR.split('.')[2] }}.{{ SERVICE_CIDR.split('.')[3]|regex_replace('/.*', '')|int + 1 }}"

--- a/roles/kube-node/vars/main.yml
+++ b/roles/kube-node/vars/main.yml
@@ -5,7 +5,7 @@ KUBE_APISERVER: "https://127.0.0.1:{{ SECURE_PORT }}"
 CGROUP_DRIVER: "systemd"
 
 # coredns 服务地址，根据SERVICE_CIDR 设置，默认选择网段第二个地址
-CLUSTER_DNS_SVC_IP: "{{ SERVICE_CIDR.split('.')[0] }}.{{ SERVICE_CIDR.split('.')[1] }}.{{ SERVICE_CIDR.split('.')[2] }}.{{ SERVICE_CIDR.split('.')[3]|int + 2 }}"
+CLUSTER_DNS_SVC_IP: "{{ SERVICE_CIDR.split('.')[0] }}.{{ SERVICE_CIDR.split('.')[1] }}.{{ SERVICE_CIDR.split('.')[2] }}.{{ SERVICE_CIDR.split('.')[3]|regex_replace('/.*', '')|int + 2 }}"
 
 # pod-max-pids
 POD_MAX_PIDS: -1

--- a/roles/kube-ovn/vars/main.yml
+++ b/roles/kube-ovn/vars/main.yml
@@ -1,5 +1,5 @@
 # CLUSTER_CIDR_GW 作为 POD_GATEWAY，选取CLUSTER_CIDR 网段中的第一个地址
-CLUSTER_CIDR_GW: "{{ CLUSTER_CIDR.split('.')[0] }}.{{ CLUSTER_CIDR.split('.')[1] }}.{{ CLUSTER_CIDR.split('.')[2] }}.{{ CLUSTER_CIDR.split('.')[3]|int + 1 }}"
+CLUSTER_CIDR_GW: "{{ CLUSTER_CIDR.split('.')[0] }}.{{ CLUSTER_CIDR.split('.')[1] }}.{{ CLUSTER_CIDR.split('.')[2] }}.{{ CLUSTER_CIDR.split('.')[3]|regex_replace('/.*', '')|int + 1 }}"
 
 # coredns 服务地址，根据SERVICE_CIDR 设置，默认选择网段第二个地址
-CLUSTER_DNS_SVC_IP: "{{ SERVICE_CIDR.split('.')[0] }}.{{ SERVICE_CIDR.split('.')[1] }}.{{ SERVICE_CIDR.split('.')[2] }}.{{ SERVICE_CIDR.split('.')[3]|int + 2 }}"
+CLUSTER_DNS_SVC_IP: "{{ SERVICE_CIDR.split('.')[0] }}.{{ SERVICE_CIDR.split('.')[1] }}.{{ SERVICE_CIDR.split('.')[2] }}.{{ SERVICE_CIDR.split('.')[3]|regex_replace('/.*', '')|int + 2 }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

修复了在 CLUSTER_DNS_SVC_IP 和 CLUSTER_KUBERNETES_SVC_IP 中，处理超出 /24 子网掩码时 IP 地址获取错误的问题。在某些情况下，当 CIDR 超过 /24 时，最后一个八位字节的 IP 地址解析不正确，导致 IP 获取失败。

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
这个修复解决了超出 /24 子网掩码时，IP 地址计算错误的问题。特别是 /25、/26 等子网掩码时，CIDR 后缀（如 /25）被去除，确保只获取纯 IP 地址并正确计算偏移。
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
