### PR TITLE
报错:已发出 HTTP 请求，正在等待回应... 403 Forbidden. 

### DIFF
--- a/ezdown
+++ b/ezdown
@@ -151,7 +151,7 @@ function download_docker() {
   else
     logger info "downloading docker binaries, arch:$ARCH, version:$DOCKER_VER"
     if [[ -e /usr/bin/wget ]];then
-      wget -c --no-check-certificate "$DOCKER_URL" || { logger error "downloading docker failed"; exit 1; }
+      wget --header="User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36" -c --no-check-certificate "$DOCKER_URL" || { logger error "downloading docker failed"; exit 1; }
     else
       curl -k -C- -O --retry 3 "$DOCKER_URL" || { logger error "downloading docker failed"; exit 1; }
     fi


### PR DESCRIPTION
@gjmzj 
wget 时会缺少请求头,curl 默认会附带一些浏览器请求头,如User-Agent: curl/7.29.0.



#### Which issue(s) this PR fixes:
```shell
[root@xx31122-test1-c7 ~]# wget https://mirrors.tuna.tsinghua.edu.cn/docker-ce/linux/static/stable/x86_64/docker-27.3.1.tgz
--2024-12-23 19:00:27--  https://mirrors.tuna.tsinghua.edu.cn/docker-ce/linux/static/stable/x86_64/docker-27.3.1.tgz
正在解析主机 mirrors.tuna.tsinghua.edu.cn (mirrors.tuna.tsinghua.edu.cn)... 101.6.15.130, 2402:f000:1:400::2
正在连接 mirrors.tuna.tsinghua.edu.cn (mirrors.tuna.tsinghua.edu.cn)|101.6.15.130|:443... 已连接。
已发出 HTTP 请求，正在等待回应... 403 Forbidden
2024-12-23 19:00:27 错误 403：Forbidden。
```
Fixes #

针对wget增加请求头.

或则不要求下载wget 二进制, 下载 ezdown 命令修改
```shell
curl -L -o ezdown https://github.com/easzlab/kubeasz/releases/download/${release}/ezdown
```

