### PR TITLE
Variable import from ezdown improved by ~11x

### DIFF
--- a/ezctl
+++ b/ezctl
@@ -149,23 +149,25 @@ function new() {
     cp example/config.yml "clusters/$1/config.yml"
 
     logger debug "set versions"
-    k8sVer=$(grep 'K8S_BIN_VER=v' ezdown|cut -d'v' -f2)
-    calicoVer=$(grep 'calicoVer=' ezdown|cut -d'=' -f2)
-    ciliumVer=$(grep 'ciliumVer=' ezdown|cut -d'=' -f2)
-    flannelVer=$(grep 'flannelVer=' ezdown|cut -d'=' -f2)
-    kubeRouterVer=$(grep 'kubeRouterVer=' ezdown|cut -d'=' -f2)
-    kubeOvnVer=$(grep 'kubeOvnVer=' ezdown|cut -d'=' -f2)
-    corednsVer=$(grep 'corednsVer=' ezdown|cut -d'=' -f2)
-    dnsNodeCacheVer=$(grep 'dnsNodeCacheVer=' ezdown|cut -d'=' -f2)
-    dashboardVer=$(grep 'dashboardVer=' ezdown|cut -d'=' -f2)
-    dashboardMetricsScraperVer=$(grep 'dashboardMetricsScraperVer=' ezdown|cut -d'=' -f2)
-    metricsVer=$(grep 'metricsVer=' ezdown|cut -d'=' -f2)
-    localpathProvisionerVer=$(grep 'localpathProvisionerVer=' ezdown|cut -d'=' -f2)
-    nfsProvisionerVer=$(grep 'nfsProvisionerVer=' ezdown|cut -d'=' -f2)
-    pauseVer=$(grep 'pauseVer=' ezdown|cut -d'=' -f2)
-    promChartVer=$(grep 'promChartVer=' ezdown|cut -d'=' -f2)
-    kubeappsVer=$(grep 'kubeappsVer=' ezdown|cut -d'=' -f2)
-    harborVer=$(grep 'HARBOR_VER=' ezdown|cut -d'=' -f2)
+    eval $(sed '/[ver|VER]=.*\./!d;s|=v|=|' ezdown)
+    k8sVer="$K8S_BIN_VER"
+    harborVer="$HARBOR_VER"
+    # these variables were imported with eval and have the same name in ezdown, setting value to itself is pointless so commented out and kept for reference
+    #calicoVer="$calicoVer"
+    #ciliumVer="$ciliumVer"
+    #flannelVer="$flannelVer"
+    #kubeRouterVer="$kubeRouterVer"
+    #kubeOvnVer="$kubeOvnVer"
+    #corednsVer="$corednsVer"
+    #dnsNodeCacheVer="$dnsNodeCacheVer"
+    #dashboardVer="$dashboardVer"
+    #dashboardMetricsScraperVer="$dashboardMetricsScraperVer"
+    #metricsVer="$metricsVer"
+    #localpathProvisionerVer="$localpathProvisionerVer"
+    #nfsProvisionerVer="$nfsProvisionerVer"
+    #pauseVer="$pauseVer"
+    #promChartVer="$promChartVer"
+    #kubeappsVer="$kubeappsVer"
     registryMirror=true
 
     grep registry-mirrors /etc/docker/daemon.json > /dev/null 2>&1 || { logger debug "disable registry mirrors"; registryMirror=false; }


### PR DESCRIPTION
… in ezdown file so used `eval` and `sed` to import values automatically while only reading the file once

<!--  Thanks for sending a pull request!  Here are some tips for you:

-->

#### What type of PR is this?

Efficiency, general code cleanup, ease of use

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
