### PR TITLE
添加节点通常无需重新执行网络插件安装，修复添加节点导致Pod重建问题

### DIFF
--- a/playbooks/22.addnode.yml
+++ b/playbooks/22.addnode.yml
@@ -9,8 +9,4 @@
   - { role: containerd, when: "CONTAINER_RUNTIME == 'containerd'" }
   - kube-lb
   - kube-node
-  - { role: calico, when: "CLUSTER_NETWORK == 'calico'" }
-  - { role: cilium, when: "CLUSTER_NETWORK == 'cilium'" }
-  - { role: flannel, when: "CLUSTER_NETWORK == 'flannel'" }
-  - { role: kube-router, when: "CLUSTER_NETWORK == 'kube-router'" }
-  - { role: kube-ovn, when: "CLUSTER_NETWORK == 'kube-ovn'" }
+  


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

安装网络插件通常是在集群安装阶段执行，添加节点无需再次安装网络插件。

#### Which issue(s) this PR fixes:

Fixes #1447

#### Special notes for your reviewer:

删除添加节点过程安装网络插件部份代码。

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
添加节点通常无需重新执行网络插件安装，修复添加节点导致Pod重建问题。
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
