### PR TITLE
fix: 移除 wget 的 user-agent 参数以修复清华源 403 问题

### DIFF
--- a/ezdown
+++ b/ezdown
@@ -170,7 +170,7 @@ function download_docker() {
   else
     logger info "downloading docker binaries, arch:$ARCH, version:$DOCKER_VER"
     if [[ -e /usr/bin/wget ]];then
-      wget -c --user-agent="Mozilla" --no-check-certificate "$DOCKER_URL" || { logger error "downloading docker failed"; exit 1; }
+      wget -c --no-check-certificate "$DOCKER_URL" || { logger error "downloading docker failed"; exit 1; }
     else
       curl -k -C- -O --retry 3 "$DOCKER_URL" || { logger error "downloading docker failed"; exit 1; }
     fi


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

移除 `ezdown` 中 wget 命令的 `--user-agent="Mozilla"` 参数。

经过大量不同ip的curl测试清华源会检测 User-Agent，当使用 `--user-agent="Mozilla"` 时无论如何都会返回 403 Forbidden，导致 `ezdown -D` 下载 docker 失败。移除该参数后，清华源和阿里源均可正常下载,除非ip超过配额。

#### Which issue(s) this PR fixes:

Fixes #1504
Fixes #1517
#### Special notes for your reviewer:

修改内容很简单，只删除了一个 wget 参数：

```diff
- wget -c --user-agent="Mozilla" --no-check-certificate "$DOCKER_URL"
+ wget -c --no-check-certificate "$DOCKER_URL"
