### PR TITLE
fix: clone failed on windows

### DIFF
--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -3,7 +3,7 @@
   with_items:
   - "{{ bin_dir }}/containerd-bin"
   - "{{ CONTAINERD_CONFIG_DIR }}/certs.d/easzlab.io.local:5000"
-  - "{{ CONTAINERD_CONFIG_DIR }}/certs.d/{{ HARBOR_REGISTRY | replace(':', '_') }}"
+  - "{{ CONTAINERD_CONFIG_DIR }}/certs.d/{{ HARBOR_REGISTRY }}"
   tags: support_private_registry
 
 - name: 准备INSECURE REGISTRY 目录

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -2,8 +2,8 @@
   file: name={{ item }} state=directory
   with_items:
   - "{{ bin_dir }}/containerd-bin"
-  - "{{ CONTAINERD_CONFIG_DIR }}/certs.d/easzlab.io.local:5000"
-  - "{{ CONTAINERD_CONFIG_DIR }}/certs.d/{{ HARBOR_REGISTRY }}"
+  - "{{ CONTAINERD_CONFIG_DIR }}/certs.d/easzlab.io.local_5000"
+  - "{{ CONTAINERD_CONFIG_DIR }}/certs.d/{{ HARBOR_REGISTRY | replace(':', '_') }}"
   tags: support_private_registry
 
 - name: 准备INSECURE REGISTRY 目录
@@ -55,7 +55,7 @@
   loop: "{{ INSECURE_REG }}"
 
 - name: 配置信任 {{ HARBOR_REGISTRY }} 仓库
-  template: src="HARBOR_REGISTRY/hosts.toml.j2" dest={{ CONTAINERD_CONFIG_DIR }}/certs.d/{{ HARBOR_REGISTRY }}/hosts.toml
+  template: src="HARBOR_REGISTRY/hosts.toml.j2" dest={{ CONTAINERD_CONFIG_DIR }}/certs.d/{{ HARBOR_REGISTRY | replace(':', '_') }}/hosts.toml
   tags: support_private_registry
 
 - name: 创建systemd unit文件

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -2,7 +2,7 @@
   file: name={{ item }} state=directory
   with_items:
   - "{{ bin_dir }}/containerd-bin"
-  - "{{ CONTAINERD_CONFIG_DIR }}/certs.d/easzlab.io.local_5000"
+  - "{{ CONTAINERD_CONFIG_DIR }}/certs.d/easzlab.io.local:5000"
   - "{{ CONTAINERD_CONFIG_DIR }}/certs.d/{{ HARBOR_REGISTRY | replace(':', '_') }}"
   tags: support_private_registry
 
@@ -50,12 +50,12 @@
 
 - name: 配置信任 INSECURE REGISTRY 仓库
   template:
-    src: hosts.toml.j2
+    src: "{{ item.split('/')[2] | replace(':', '_') }}/hosts.toml.j2"
     dest: "{{ CONTAINERD_CONFIG_DIR }}/certs.d/{{ item.split('/')[2] }}/hosts.toml"
   loop: "{{ INSECURE_REG }}"
 
 - name: 配置信任 {{ HARBOR_REGISTRY }} 仓库
-  template: src="HARBOR_REGISTRY/hosts.toml.j2" dest={{ CONTAINERD_CONFIG_DIR }}/certs.d/{{ HARBOR_REGISTRY | replace(':', '_') }}/hosts.toml
+  template: src="HARBOR_REGISTRY/hosts.toml.j2" dest={{ CONTAINERD_CONFIG_DIR }}/certs.d/{{ HARBOR_REGISTRY }}/hosts.toml
   tags: support_private_registry
 
 - name: 创建systemd unit文件

--- a/roles/containerd/templates/easzlab.io.local:5000/hosts.toml.j2
+++ b/roles/containerd/templates/easzlab.io.local:5000/hosts.toml.j2
@@ -1,6 +1,0 @@
-#https://github.com/containerd/containerd/blob/main/docs/hosts.md
-server = "http://easzlab.io.local:5000"
-
-[host."http://easzlab.io.local:5000"]
-  capabilities = ["pull", "resolve"]
-  skip_verify = true

--- a/roles/containerd/templates/easzlab.io.local_5000/hosts.toml.j2
+++ b/roles/containerd/templates/easzlab.io.local_5000/hosts.toml.j2
@@ -1,0 +1,6 @@
+#https://github.com/containerd/containerd/blob/main/docs/hosts.md
+server = "http://easzlab.io.local:5000"
+
+[host."http://easzlab.io.local:5000"]
+  capabilities = ["pull", "resolve"]
+  skip_verify = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
git clone https://github.com/easzlab/kubeasz.git
报错
error: invalid path 'roles/containerd/templates/easzlab.io.local:5000/hosts.toml.j2'
fatal: unable to checkout working tree
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry with 'git restore --source=HEAD :/'


这个错误不是 Git clone 失败，而是 checkout 失败。


error: invalid path 'roles/containerd/templates/easzlab.io.local:5000/hosts.toml.j2'
fatal: unable to checkout working tree

原因基本只有一种：你当前使用的是 Windows 文件系统（NTFS），而仓库中包含了 Windows 不允许的文件名 ,因此修改文件名中的冒号为下划线

